### PR TITLE
[feat] #24 회원 관련 누락 기능 추가

### DIFF
--- a/src/main/java/com/numble/team3/common/advice/CommonRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/common/advice/CommonRestControllerAdvice.java
@@ -1,0 +1,25 @@
+package com.numble.team3.common.advice;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CommonRestControllerAdvice {
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> httpMessageNotReadableException() {
+    return createResponse("json 형식을 올바르게 작성해주세요.");
+  }
+
+  private Map<String, String> createResponse(String message) {
+    Map<String, String> response = new HashMap<>();
+    response.put("message", message);
+    return response;
+  }
+}

--- a/src/main/java/com/numble/team3/exception/account/AccountWithdrawalException.java
+++ b/src/main/java/com/numble/team3/exception/account/AccountWithdrawalException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.account;
+
+public class AccountWithdrawalException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/sign/application/SignService.java
+++ b/src/main/java/com/numble/team3/sign/application/SignService.java
@@ -13,4 +13,6 @@ public interface SignService {
   TokenDto createAccessTokenByRefreshToken(String refreshToken);
 
   void logout(String accessToken);
+
+  void withdrawal(String accessToken);
 }

--- a/src/main/java/com/numble/team3/sign/application/advice/SignRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/sign/application/advice/SignRestControllerAdvice.java
@@ -1,5 +1,9 @@
 package com.numble.team3.sign.application.advice;
 
+import com.numble.team3.exception.account.AccountEmailAlreadyExistsException;
+import com.numble.team3.exception.account.AccountNicknameAlreadyExistsException;
+import com.numble.team3.exception.account.AccountNotFoundException;
+import com.numble.team3.exception.account.AccountWithdrawalException;
 import com.numble.team3.exception.sign.SignInFailureException;
 import com.numble.team3.exception.sign.TokenFailureException;
 import com.numble.team3.sign.controller.SignController;
@@ -7,6 +11,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,10 +20,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(assignableTypes = {SignController.class})
 public class SignRestControllerAdvice {
 
-  @ExceptionHandler(BindException.class)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  Map<String, String> bindException(BindException e) {
+  Map<String, String> methodArgumentNotValidExceptionHandler(BindException e) {
     return createResponse(e.getBindingResult().getFieldError().getDefaultMessage());
+  }
+
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> missingRequestHeaderExceptionHandler() {
+    return createResponse("Authorization 헤더가 누락되었습니다.");
   }
 
   @ExceptionHandler(TokenFailureException.class)
@@ -30,6 +42,36 @@ public class SignRestControllerAdvice {
   @ResponseStatus(HttpStatus.UNAUTHORIZED)
   Map<String, String> signInFailureException() {
     return createResponse("로그인에 실패했습니다.");
+  }
+
+  @ExceptionHandler(AccountEmailAlreadyExistsException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  Map<String, String> accountEmailAlreadyExistsExceptionHandler() {
+    return createResponse("이미 존재하는 이메일입니다.");
+  }
+
+  @ExceptionHandler(AccountNicknameAlreadyExistsException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  Map<String, String> accountNicknameAlreadyExistsExceptionHandler() {
+    return createResponse("이미 존재하는 닉네임입니다.");
+  }
+
+  @ExceptionHandler(AccountNotFoundException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> accountNotFoundExceptionHandler() {
+    return createResponse("존재하지 않는 이메일입니다.");
+  }
+
+  @ExceptionHandler(AccountWithdrawalException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> accountWithdrawalExceptionHandler() {
+    return createResponse("이미 탈퇴처리 된 계정입니다.");
+  }
+
+  @ExceptionHandler(NullPointerException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String>  nullPointerException() {
+    return createResponse("refreshToken 쿠키가 누락되었습니다.");
   }
 
   private Map<String, String> createResponse(String message) {

--- a/src/main/java/com/numble/team3/sign/controller/SignController.java
+++ b/src/main/java/com/numble/team3/sign/controller/SignController.java
@@ -16,6 +16,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,6 +67,15 @@ public class SignController {
     Map<String, String> message = new HashMap<>();
     message.put("message", "refreshToken 쿠키가 누락되었습니다.");
     return new ResponseEntity(message, HttpStatus.UNAUTHORIZED);
+  }
+
+  @DeleteMapping("/withdrawal")
+  public ResponseEntity accountWithdrawal(
+    @RequestHeader(value = "Authorization") String accessToken, HttpServletResponse response) {
+    signService.withdrawal(accessToken);
+    deleteCookie(response);
+
+    return new ResponseEntity(HttpStatus.OK);
   }
 
   private void createCookie(String token, int maxAge, HttpServletResponse response) {


### PR DESCRIPTION
## 개요
- #24 

## 처리사항
- 회원 탈퇴 기능 추가
    - `SignController`에 `accountWithdrawal` 메소드를 추가했습니다.
    - `SignService`에 `void withdrawal(String accessToken)` 메소드를 추가했습니다.
        - `RedisSignService`에 구현했습니다.
- 예외를 처리하는 기능 `RestControllerAdvice` 추가했습니다.
    - `/common/advice/CommonRestControllerAdvice`
        - `json` 형식에 맞지 않는 경우 발생하는 예외를 처리하는 `RestControllerAdvice` 입니다.
        - 전반적으로 필요할 것이라 판단해 `common` 패키지에 추가했습니다.
    - `/sign/advice/SignRestControllerAdvice`
        - `signController`에서 발생하는 예외를 처리하는 `RestControllerAdvice` 입니다.