### PR TITLE
[feat] #28 비디오 도메인 및 LoginArgumentResolver 보완 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 	//스웨거 설정
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+
+	compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.7.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/numble/team3/common/advice/CommonRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/common/advice/CommonRestControllerAdvice.java
@@ -1,20 +1,45 @@
 package com.numble.team3.common.advice;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
 
 @RestControllerAdvice
+@Slf4j
 public class CommonRestControllerAdvice {
 
   @ExceptionHandler(HttpMessageNotReadableException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   Map<String, String> httpMessageNotReadableException() {
     return createResponse("json 형식을 올바르게 작성해주세요.");
+  }
+
+  @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public Map<String, Object> handleConstraintViolationException(
+      final MethodArgumentNotValidException ex, final ServletWebRequest request) {
+    final List<InvalidParameterDto> invalidParameters =
+        ex.getBindingResult().getFieldErrors().stream()
+            .map(
+                fieldError ->
+                    InvalidParameterDto.builder()
+                        .parameter(fieldError.getField())
+                        .message(fieldError.getDefaultMessage())
+                        .build())
+            .collect(Collectors.toList());
+    Map<String, Object> response = new HashMap<>();
+    response.put("message", "파라미터 형식이 잘못되었습니다.");
+    response.put("invalidParameters", invalidParameters);
+    return response;
   }
 
   private Map<String, String> createResponse(String message) {

--- a/src/main/java/com/numble/team3/common/advice/CommonRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/common/advice/CommonRestControllerAdvice.java
@@ -1,0 +1,25 @@
+package com.numble.team3.common.advice;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CommonRestControllerAdvice {
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> httpMessageNotReadableException() {
+    return createResponse("json 형식을 올바르게 작성해주세요.");
+  }
+
+  private Map<String, String> createResponse(String message) {
+    Map<String, String> response = new HashMap<>();
+    response.put("message", message);
+    return response;
+  }
+}

--- a/src/main/java/com/numble/team3/common/advice/InvalidParameterDto.java
+++ b/src/main/java/com/numble/team3/common/advice/InvalidParameterDto.java
@@ -1,0 +1,21 @@
+package com.numble.team3.common.advice;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class InvalidParameterDto {
+  @ApiModelProperty(value = "invalid 파라미터 이름")
+  private String parameter;
+
+  @ApiModelProperty(value = "예외 발생 이유")
+  private String message;
+}

--- a/src/main/java/com/numble/team3/exception/account/AccountWithdrawalException.java
+++ b/src/main/java/com/numble/team3/exception/account/AccountWithdrawalException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.account;
+
+public class AccountWithdrawalException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/sign/application/SignService.java
+++ b/src/main/java/com/numble/team3/sign/application/SignService.java
@@ -13,4 +13,6 @@ public interface SignService {
   TokenDto createAccessTokenByRefreshToken(String refreshToken);
 
   void logout(String accessToken);
+
+  void withdrawal(String accessToken);
 }

--- a/src/main/java/com/numble/team3/sign/application/advice/SignRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/sign/application/advice/SignRestControllerAdvice.java
@@ -1,5 +1,9 @@
 package com.numble.team3.sign.application.advice;
 
+import com.numble.team3.exception.account.AccountEmailAlreadyExistsException;
+import com.numble.team3.exception.account.AccountNicknameAlreadyExistsException;
+import com.numble.team3.exception.account.AccountNotFoundException;
+import com.numble.team3.exception.account.AccountWithdrawalException;
 import com.numble.team3.exception.sign.SignInFailureException;
 import com.numble.team3.exception.sign.TokenFailureException;
 import com.numble.team3.sign.controller.SignController;
@@ -7,6 +11,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,10 +20,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(assignableTypes = {SignController.class})
 public class SignRestControllerAdvice {
 
-  @ExceptionHandler(BindException.class)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  Map<String, String> bindException(BindException e) {
+  Map<String, String> methodArgumentNotValidExceptionHandler(BindException e) {
     return createResponse(e.getBindingResult().getFieldError().getDefaultMessage());
+  }
+
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> missingRequestHeaderExceptionHandler() {
+    return createResponse("Authorization 헤더가 누락되었습니다.");
   }
 
   @ExceptionHandler(TokenFailureException.class)
@@ -30,6 +42,36 @@ public class SignRestControllerAdvice {
   @ResponseStatus(HttpStatus.UNAUTHORIZED)
   Map<String, String> signInFailureException() {
     return createResponse("로그인에 실패했습니다.");
+  }
+
+  @ExceptionHandler(AccountEmailAlreadyExistsException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  Map<String, String> accountEmailAlreadyExistsExceptionHandler() {
+    return createResponse("이미 존재하는 이메일입니다.");
+  }
+
+  @ExceptionHandler(AccountNicknameAlreadyExistsException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  Map<String, String> accountNicknameAlreadyExistsExceptionHandler() {
+    return createResponse("이미 존재하는 닉네임입니다.");
+  }
+
+  @ExceptionHandler(AccountNotFoundException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> accountNotFoundExceptionHandler() {
+    return createResponse("존재하지 않는 이메일입니다.");
+  }
+
+  @ExceptionHandler(AccountWithdrawalException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> accountWithdrawalExceptionHandler() {
+    return createResponse("이미 탈퇴처리 된 계정입니다.");
+  }
+
+  @ExceptionHandler(NullPointerException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String>  nullPointerException() {
+    return createResponse("refreshToken 쿠키가 누락되었습니다.");
   }
 
   private Map<String, String> createResponse(String message) {

--- a/src/main/java/com/numble/team3/sign/controller/SignController.java
+++ b/src/main/java/com/numble/team3/sign/controller/SignController.java
@@ -16,6 +16,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,6 +67,15 @@ public class SignController {
     Map<String, String> message = new HashMap<>();
     message.put("message", "refreshToken 쿠키가 누락되었습니다.");
     return new ResponseEntity(message, HttpStatus.UNAUTHORIZED);
+  }
+
+  @DeleteMapping("/withdrawal")
+  public ResponseEntity accountWithdrawal(
+    @RequestHeader(value = "Authorization") String accessToken, HttpServletResponse response) {
+    signService.withdrawal(accessToken);
+    deleteCookie(response);
+
+    return new ResponseEntity(HttpStatus.OK);
   }
 
   private void createCookie(String token, int maxAge, HttpServletResponse response) {

--- a/src/main/java/com/numble/team3/video/application/VideoService.java
+++ b/src/main/java/com/numble/team3/video/application/VideoService.java
@@ -57,7 +57,7 @@ public class VideoService {
 
   @Transactional(readOnly = true)
   public GetVideoListDto getAllVideo(PageRequest pageRequest) {
-    return GetVideoListDto.fromEntities(videoRepository.findAll(pageRequest).getContent());
+    return GetVideoListDto.fromEntities(videoRepository.findAllWithAccount(pageRequest));
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/numble/team3/video/application/response/GetVideoDetailDto.java
+++ b/src/main/java/com/numble/team3/video/application/response/GetVideoDetailDto.java
@@ -1,5 +1,10 @@
 package com.numble.team3.video.application.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.numble.team3.video.domain.Video;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -7,17 +12,23 @@ import lombok.Getter;
 
 @Getter
 public class GetVideoDetailDto {
+  private long videoId;
   private String thumbnailPath;
   private String title;
   private String content;
   private String nickname;
   private long view;
   private long like;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
   private LocalDateTime createdAt;
+
   private String category;
 
   @Builder
   private GetVideoDetailDto(
+      long videoId,
       String thumbnailPath,
       String title,
       String content,
@@ -26,6 +37,7 @@ public class GetVideoDetailDto {
       long like,
       LocalDateTime createdAt,
       String category) {
+    this.videoId = videoId;
     this.thumbnailPath = thumbnailPath;
     this.title = title;
     this.content = content;
@@ -38,6 +50,7 @@ public class GetVideoDetailDto {
 
   public static GetVideoDetailDto fromEntity(Video video) {
     return GetVideoDetailDto.builder()
+        .videoId(video.getId())
         .thumbnailPath(video.getThumbnailUrl())
         .title(video.getTitle())
         .content(video.getContent())

--- a/src/main/java/com/numble/team3/video/application/response/GetVideoListDto.java
+++ b/src/main/java/com/numble/team3/video/application/response/GetVideoListDto.java
@@ -1,5 +1,8 @@
 package com.numble.team3.video.application.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.numble.team3.video.domain.Video;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,21 +17,27 @@ public class GetVideoListDto {
 
   @Getter
   static class GetVideoDto {
+    private long videoId;
     private String thumbnailPath;
     private String title;
     private String nickname;
     private long view;
     private long like;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     private LocalDateTime createdAt;
 
     @Builder
     public GetVideoDto(
+        long videoId,
         String thumbnailPath,
         String title,
         String nickname,
         long view,
         long like,
         LocalDateTime createdAt) {
+      this.videoId = videoId;
       this.thumbnailPath = thumbnailPath;
       this.title = title;
       this.nickname = nickname;
@@ -39,6 +48,7 @@ public class GetVideoListDto {
 
     static GetVideoDto fromEntity(Video video) {
       return GetVideoDto.builder()
+          .videoId(video.getId())
           .thumbnailPath(video.getThumbnailUrl())
           .title(video.getTitle())
           .nickname(video.getAccount().getNickname())

--- a/src/main/java/com/numble/team3/video/domain/Video.java
+++ b/src/main/java/com/numble/team3/video/domain/Video.java
@@ -50,12 +50,17 @@ public class Video {
   private String thumbnailUrl;
 
   @Column(columnDefinition = "tinyint(1)")
-  private boolean deleteYn;
+  private boolean deleteYn = false;
+
+  @Column(columnDefinition = "tinyint(1)")
+  private boolean adminDeleteYn = false;
 
   @ManyToOne private Account account;
 
   @Enumerated(EnumType.STRING)
   private VideoCategory category;
+
+  private Long showId = Long.valueOf(Integer.MAX_VALUE);
 
   @Builder
   public Video(
@@ -74,7 +79,6 @@ public class Video {
     this.videoUrl = videoUrl;
     this.thumbnailUrl = thumbnailUrl;
     this.account = account;
-    this.deleteYn = false;
     this.category = category;
   }
 

--- a/src/main/java/com/numble/team3/video/infra/JpaVideoRepository.java
+++ b/src/main/java/com/numble/team3/video/infra/JpaVideoRepository.java
@@ -1,11 +1,17 @@
 package com.numble.team3.video.infra;
 
 import com.numble.team3.video.domain.Video;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaVideoRepository extends JpaRepository<Video, Long> {
   Optional<Video> findByAccountIdAndId(Long accountId, Long videoId);
+
+  @Query("SELECT v FROM Video v JOIN FETCH v.account WHERE v.deleteYn = false")
+  List<Video> findAllWithAccount(Pageable pageable);
 }


### PR DESCRIPTION
## 개요
- #28 
## 처리사항
- Authorization 헤더에서 accessToken 값 추출하도록 수정
- Response Dto의 LocalDateTime을 직렬화하도록 어노테이션 추가
- 관리자 삭제 여부 칼럼 추가, 비디오 리스트 조회 방식 - 페치조인으로 수정
- invalid 파라미터를 보여주도록 컨트롤러 어드바이스 추가