### PR TITLE
[rename] 기존의 RedisUtils를 SignRedisUtils로 이름 변경

### DIFF
--- a/src/main/java/com/numble/team3/config/SecurityConfig.java
+++ b/src/main/java/com/numble/team3/config/SecurityConfig.java
@@ -7,7 +7,7 @@ import com.numble.team3.security.CustomOAuth2UserService;
 import com.numble.team3.security.CustomUserDetailsService;
 import com.numble.team3.security.JwtAuthenticationFilter;
 import com.numble.team3.security.OAuth2SuccessHandler;
-import com.numble.team3.sign.infra.RedisUtils;
+import com.numble.team3.sign.infra.SignRedisUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -21,7 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   private final CustomUserDetailsService userDetailsService;
-  private final RedisUtils redisUtils;
+  private final SignRedisUtils signRedisUtils;
   private final TokenHelper accessTokenHelper;
   private final CustomOAuth2UserService oAuth2UserService;
   private final OAuth2SuccessHandler oAuth2SuccessHandler;
@@ -53,7 +53,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       .exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
       .and()
       .addFilterBefore(
-        new JwtAuthenticationFilter(userDetailsService, redisUtils, accessTokenHelper),
+        new JwtAuthenticationFilter(userDetailsService, signRedisUtils, accessTokenHelper),
         UsernamePasswordAuthenticationFilter.class)
 
       .oauth2Login()

--- a/src/main/java/com/numble/team3/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/numble/team3/security/JwtAuthenticationFilter.java
@@ -1,17 +1,13 @@
 package com.numble.team3.security;
 
 import com.numble.team3.jwt.TokenHelper;
-import com.numble.team3.sign.infra.RedisUtils;
+import com.numble.team3.sign.infra.SignRedisUtils;
 import java.io.IOException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Optional;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,13 +17,13 @@ import org.springframework.web.filter.GenericFilterBean;
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
   private final CustomUserDetailsService userDetailsService;
-  private final RedisUtils redisUtils;
+  private final SignRedisUtils signRedisUtils;
   private final TokenHelper accessTokenHelper;
 
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
     throws IOException, ServletException {
-    extractToken(request).filter(token -> redisUtils.validToken(token, "accessToken",
+    extractToken(request).filter(token -> signRedisUtils.validToken(token, "accessToken",
         Optional.ofNullable(
           accessTokenHelper.parse(token).map(claims -> claims.getAccountId()).orElse(null))))
       .map(userDetailsService::loadUserByUsername).ifPresent(this::setAuthentication);

--- a/src/main/java/com/numble/team3/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/numble/team3/security/OAuth2SuccessHandler.java
@@ -6,7 +6,7 @@ import com.numble.team3.account.infra.JpaAccountRepository;
 import com.numble.team3.jwt.PrivateClaims;
 import com.numble.team3.jwt.TokenHelper;
 import com.numble.team3.sign.application.response.TokenDto;
-import com.numble.team3.sign.infra.RedisUtils;
+import com.numble.team3.sign.infra.SignRedisUtils;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
@@ -31,7 +31,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
   private final JpaAccountRepository accountRepository;
   private final TokenHelper accessTokenHelper;
   private final TokenHelper refreshTokenHelper;
-  private final RedisUtils redisUtils;
+  private final SignRedisUtils signRedisUtils;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -55,8 +55,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     String accessToken = accessTokenHelper.createToken(privateClaims);
     String refreshToken = refreshTokenHelper.createToken(privateClaims);
 
-    redisUtils.saveAccessToken(account.getId(), accessToken);
-    redisUtils.saveRefreshToken(account.getId(), refreshToken);
+    signRedisUtils.saveAccessToken(account.getId(), accessToken);
+    signRedisUtils.saveRefreshToken(account.getId(), refreshToken);
 
     createTokenCookie(response, refreshToken);
     try {

--- a/src/main/java/com/numble/team3/sign/infra/SignRedisUtils.java
+++ b/src/main/java/com/numble/team3/sign/infra/SignRedisUtils.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RedisUtils {
+public class SignRedisUtils {
 
   private final RedisTemplate redisTemplate;
   private final TokenHelper accessTokenHelper;


### PR DESCRIPTION
## 개요
- RedisUtils 이름 변경

## 작업 내용
- `sign/infra/RedisUtils`의 이름을 `SignRedisUtils`로 변경했습니다.
- 비디오 조회수라거나 회원 마지막 로그인 시간 등 사용해야 할 구간이 많아졌기 때문에 `Sign`에 특화된 이름으로 변경했습니다.