### PR TITLE
[feat] 회원 로그인 시간 저장

### DIFF
--- a/src/main/java/com/numble/team3/Team3Application.java
+++ b/src/main/java/com/numble/team3/Team3Application.java
@@ -3,9 +3,11 @@ package com.numble.team3;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class Team3Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/numble/team3/account/application/AccountService.java
+++ b/src/main/java/com/numble/team3/account/application/AccountService.java
@@ -1,0 +1,35 @@
+package com.numble.team3.account.application;
+
+import com.numble.team3.account.domain.Account;
+import com.numble.team3.account.infra.AccountRedisUtils;
+import com.numble.team3.account.infra.JpaAccountRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AccountService {
+
+  private final JpaAccountRepository accountRepository;
+  private final AccountRedisUtils accountRedisUtils;
+
+  public void changeAccountLastLoginByScheduler() {
+    List<Account> accounts = accountRepository.findAll();
+
+    List<Long> accountIds = accountRedisUtils.getAllLastLoginKey();
+
+    accounts
+      .stream().filter(account -> accountIds.contains(account.getId()))
+      .forEach(account -> {
+        String lastLoginTime =
+          accountRedisUtils.getLastLogin(account.getId()).orElseThrow(RuntimeException::new);
+        if (!(account.getLastLogin() != null && account.getLastLogin().equals(lastLoginTime))) {
+          account.changeLastLogin(lastLoginTime);
+        }});
+
+    accountIds.stream().forEach(accountId -> accountRedisUtils.deleteLastLogin(accountId));
+  }
+}

--- a/src/main/java/com/numble/team3/account/domain/Account.java
+++ b/src/main/java/com/numble/team3/account/domain/Account.java
@@ -45,6 +45,9 @@ public class Account {
   @Column(columnDefinition = "tinyint(1)")
   private boolean deleted;
 
+  @Column
+  private String lastLogin;
+
   public static Account createSignUpOauth2Account(String email, String nickname, String profile) {
     Account account = new Account();
     account.initSignUpOauth2AccountField(email, nickname, profile);
@@ -71,5 +74,9 @@ public class Account {
 
   public void changeDeleted(boolean deleted) {
     this.deleted = deleted;
+  }
+
+  public void changeLastLogin(String lastLogin) {
+    this.lastLogin = lastLogin;
   }
 }

--- a/src/main/java/com/numble/team3/account/infra/AccountRedisUtils.java
+++ b/src/main/java/com/numble/team3/account/infra/AccountRedisUtils.java
@@ -1,0 +1,42 @@
+package com.numble.team3.account.infra;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AccountRedisUtils {
+
+  private final RedisTemplate redisTemplate;
+  private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+  private static final String SEPARATOR = "::";
+
+  public void saveLastLogin(Long id) {
+    redisTemplate.opsForValue()
+      .set("lastLogin" + SEPARATOR + id, formatter.format(LocalDateTime.now()));
+  }
+
+  public void deleteLastLogin(Long id) {
+    redisTemplate.delete("lastLogin" + SEPARATOR + id);
+  }
+
+  public Optional<String> getLastLogin(Long id) {
+    return Optional.ofNullable(
+      (String) redisTemplate.opsForValue().get("lastLogin" + SEPARATOR + id));
+  }
+
+  public List<Long> getAllLastLoginKey() {
+    Set<String> keys = redisTemplate.keys("lastLogin::*");
+
+    return keys.stream().map(key -> Long.valueOf(key.split("::")[1])).collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/com/numble/team3/account/scheduler/AccountLastLoginScheduler.java
+++ b/src/main/java/com/numble/team3/account/scheduler/AccountLastLoginScheduler.java
@@ -1,0 +1,18 @@
+package com.numble.team3.account.scheduler;
+
+import com.numble.team3.account.application.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AccountLastLoginScheduler {
+
+  private final AccountService accountService;
+
+  @Scheduled(cron = "0 0 0 * * *")
+  protected void changeAccountLastLogin() {
+    accountService.changeAccountLastLoginByScheduler();
+  }
+}

--- a/src/main/java/com/numble/team3/sign/application/RedisSignService.java
+++ b/src/main/java/com/numble/team3/sign/application/RedisSignService.java
@@ -1,6 +1,7 @@
 package com.numble.team3.sign.application;
 
 import com.numble.team3.account.domain.Account;
+import com.numble.team3.account.infra.AccountRedisUtils;
 import com.numble.team3.exception.account.AccountEmailAlreadyExistsException;
 import com.numble.team3.exception.account.AccountNicknameAlreadyExistsException;
 import com.numble.team3.account.infra.JpaAccountRepository;
@@ -30,6 +31,7 @@ public class RedisSignService implements SignService {
   private final TokenHelper accessTokenHelper;
   private final TokenHelper refreshTokenHelper;
   private final SignRedisUtils signRedisUtils;
+  private final AccountRedisUtils accountRedisUtils;
 
   @Transactional
   @Override
@@ -57,6 +59,7 @@ public class RedisSignService implements SignService {
 
     signRedisUtils.saveAccessToken(account.getId(), accessToken);
     signRedisUtils.saveRefreshToken(account.getId(), refreshToken);
+    accountRedisUtils.saveLastLogin(account.getId());
 
     return new TokenDto(accessToken, refreshToken);
   }


### PR DESCRIPTION
## 개요
- #30 
- 회원 로그인 시 로그인 시간을 `yyyy.MM.dd` 포맷으로 `Redis`에 저장하고, 매일 자정마다 회원의 마지막 로그인 시간을 업데이트하는 기능을 추가했습니다.

## 작업사항
- 스케쥴러를 사용하기 위해 스프링 부트 메인문에 `@EnableScheduling`를 추가했습니다.
- `Account` 엔티티에 `lastLogin` 필드와 해당 필드를 변경하는 메소드 `changeLastLogin`를 추가했습니다.
- `AccountLastLoginScheduler`를 추가했습니다.
- `AccountRedisUtils`를 추가했습니다.
    - `cron`을 활용해 매일 자정마다 동작하도록 설정했습니다.
- `AccountService`를 추가했습니다.
    - 스케쥴러에 의해 호출되는 메소드 `changeAccountLastLoginByScheduler`만 정의해놨습니다.
- `RedisSignService`의 `SignIn` 메소드 동작에 `AccountRedisUtils`를 통해 회원의 로그인 시간을 저장하도록 로직을 추가했습니다.