### PR TITLE
[feat] #39 Image 리사이즈 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	//스웨거 설정
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '3.0.0'

--- a/src/main/java/com/numble/team3/exception/image/ImageConvertFailureException.java
+++ b/src/main/java/com/numble/team3/exception/image/ImageConvertFailureException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.image;
+
+public class ImageConvertFailureException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/exception/image/ImageResizeTypeUnSupportException.java
+++ b/src/main/java/com/numble/team3/exception/image/ImageResizeTypeUnSupportException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.image;
+
+public class ImageResizeTypeUnSupportException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/exception/image/ImageTypeUnSupportException.java
+++ b/src/main/java/com/numble/team3/exception/image/ImageTypeUnSupportException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.image;
+
+public class ImageTypeUnSupportException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/image/application/ApiGatewayImageService.java
+++ b/src/main/java/com/numble/team3/image/application/ApiGatewayImageService.java
@@ -1,0 +1,91 @@
+package com.numble.team3.image.application;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numble.team3.exception.image.ImageConvertFailureException;
+import com.numble.team3.exception.image.ImageTypeUnSupportException;
+import com.numble.team3.image.application.request.CreateImageDto;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class ApiGatewayImageService implements ImageService {
+
+  private static final List<String> IMAGE_TYPE = List.of("jpeg", "png", "jpg");
+
+  @Value("${cloud.aws.image.s3.name}")
+  private String bucket;
+
+  @Value("${cloud.aws.image.api-gateway.url}")
+  private String apiGateway;
+
+  private final AmazonS3Client amazonS3Client;
+
+  @Override
+  public String uploadResizeImage(CreateImageDto dto) throws IOException {
+    String filename = createFilename(dto.getFile().getOriginalFilename());
+    ObjectMetadata objectMetadata = generateObjectMetaData(dto.getFile());
+
+    amazonS3Client.putObject(bucket, filename, dto.getFile().getInputStream(), objectMetadata);
+
+    return processApiGateway(filename, dto.getWidth(), dto.getHeight(), dto.getType());
+  }
+
+  private String createFilename(String originalFilename) {
+    String ext = originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
+
+    if (!(IMAGE_TYPE.contains(ext))) {
+      throw new ImageTypeUnSupportException();
+    }
+
+    return UUID.randomUUID().toString().substring(0, 10) + "." + ext;
+  }
+
+  private String processApiGateway(String filename, String width, String height, String type) {
+    WebClient webClient = WebClient.builder()
+      .baseUrl(apiGateway)
+      .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+      .build();
+
+    String result = webClient.post()
+      .uri("/images")
+      .bodyValue(
+        new HashMap<String, String>() {
+          {
+            put("filename", filename);
+            put("width", width);
+            put("height", height);
+            put("type", type);
+          }
+        })
+      .retrieve()
+      .bodyToMono(String.class).block();
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      Map<String, String> resultMap = objectMapper.readValue(result, Map.class);
+      return resultMap.get("url");
+    } catch (Exception e) {
+      throw new ImageConvertFailureException();
+    }
+  }
+
+  private ObjectMetadata generateObjectMetaData(MultipartFile file) {
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(file.getSize());
+    objectMetadata.setContentType(file.getContentType());
+    return objectMetadata;
+  }
+}

--- a/src/main/java/com/numble/team3/image/application/ImageService.java
+++ b/src/main/java/com/numble/team3/image/application/ImageService.java
@@ -1,0 +1,9 @@
+package com.numble.team3.image.application;
+
+import com.numble.team3.image.application.request.CreateImageDto;
+import java.io.IOException;
+
+public interface ImageService {
+
+  String uploadResizeImage(CreateImageDto dto) throws IOException;
+}

--- a/src/main/java/com/numble/team3/image/application/advice/ImageRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/image/application/advice/ImageRestControllerAdvice.java
@@ -1,0 +1,48 @@
+package com.numble.team3.image.application.advice;
+
+import com.numble.team3.exception.image.ImageConvertFailureException;
+import com.numble.team3.exception.image.ImageResizeTypeUnSupportException;
+import com.numble.team3.exception.image.ImageTypeUnSupportException;
+import com.numble.team3.image.controller.ImageController;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = {ImageController.class})
+public class ImageRestControllerAdvice {
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> methodArgumentNotValidExceptionHandler(BindException e) {
+    return createResponse(e.getBindingResult().getFieldError().getDefaultMessage());
+  }
+
+  @ExceptionHandler(ImageResizeTypeUnSupportException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> imageResizeTypeUnSupportException() {
+    return createResponse("지원하지 않는 리사이즈 방식입니다.");
+  }
+
+  @ExceptionHandler(ImageTypeUnSupportException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> imageTypeUnSupportExceptionHandler() {
+    return createResponse("지원하지 않는 이미지 파일입니다.");
+  }
+
+  @ExceptionHandler(ImageConvertFailureException.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  Map<String, String> imageConvertFailureExceptionHandler(BindException e) {
+    return createResponse("이미지 변환에 실패했습니다.");
+  }
+
+  private Map<String, String> createResponse(String message) {
+    Map<String, String> response = new HashMap<>();
+    response.put("message", message);
+    return response;
+  }
+}

--- a/src/main/java/com/numble/team3/image/application/request/CreateImageDto.java
+++ b/src/main/java/com/numble/team3/image/application/request/CreateImageDto.java
@@ -1,0 +1,23 @@
+package com.numble.team3.image.application.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class CreateImageDto {
+
+  @NotBlank(message = "업로드할 이미지 파일을 선택해주세요.")
+  private MultipartFile file;
+
+  @NotBlank(message = "리사이즈할 가로 길이를 입력해주세요.")
+  private String width;
+
+  @NotBlank(message = "라사이즈할 세로 길이를 입력해주세요.")
+  private String height;
+
+  @NotBlank(message = "리사이즈할 타입을 입력해주세요.")
+  private String type;
+}

--- a/src/main/java/com/numble/team3/image/controller/ImageController.java
+++ b/src/main/java/com/numble/team3/image/controller/ImageController.java
@@ -1,0 +1,36 @@
+package com.numble.team3.image.controller;
+
+import com.numble.team3.exception.image.ImageResizeTypeUnSupportException;
+import com.numble.team3.image.application.ImageService;
+import com.numble.team3.image.application.request.CreateImageDto;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ImageController {
+
+  private final ImageService imageService;
+
+  @PostMapping(value = "/images/resize", produces = "application/json")
+  public ResponseEntity<Map> imageResize(@ModelAttribute CreateImageDto dto) throws IOException {
+    if (!(dto.getType().equals("profile") || dto.getType().equals("thumbnail"))) {
+      throw new ImageResizeTypeUnSupportException();
+    }
+
+    return new ResponseEntity(new HashMap<String, String>() {
+      {
+        put("url", imageService.uploadResizeImage(dto));
+      }
+    }, HttpStatus.CREATED);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,11 +37,16 @@ spring:
 cloud:
   aws:
     credentials:
-      access-key: dummy-password
-      secret-key: dummy-password
+      access-key: dummy-data
+      secret-key: dummy-data
     region:
       static: ap-northeast-2
     s3:
       bucket: numble-video
     stack:
       auto: false
+    image:
+      s3:
+        name: numble-image
+      api-gateway:
+        url: image-api-gateway-url


### PR DESCRIPTION
## 개요
- #39 

## 작업사항
- `Api Gateway`, `Lambda` 조합으로 처리했습니다.
- 유연한 리사이즈를 위해 리사이즈 타입(`thumbnail`, `profile`)과 이미지 가로, 세로를 필요로 합니다.
- 다음과 같은 과정을 통해 이미지가 리사이즈됩니다.
    - 원본 이미지 `s3`에 업로드
        - 메타데이터를 `lambda`에서 가져오기 위함입니다.
    - 애플리케이션에서 `api gateway` 호출
    - `api gateway`가 `lambda` 호출
    - `lambda`에서 원본 이미지를 `s3`에서 조회
    - `api gateway`에 전달한 정보를 토대로 리사이즈 진행
    - 리사이즈 방식에 따라 `s3` 경로에 저장
    - 원본 이미지 삭제
    - 업로드한 이미지의 경로에 맞는 `cloudfront url` 응답 메세지로 반환