### PR TITLE
#51, #40 관심영상(Like) 관련 기능 추가

### DIFF
--- a/src/main/java/com/numble/team3/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/numble/team3/common/entity/BaseTimeEntity.java
@@ -1,0 +1,19 @@
+package com.numble.team3.common.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/numble/team3/config/QuerydslConfig.java
+++ b/src/main/java/com/numble/team3/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.numble.team3.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+  private final EntityManager em;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(em);
+  }
+}

--- a/src/main/java/com/numble/team3/config/WebConfig.java
+++ b/src/main/java/com/numble/team3/config/WebConfig.java
@@ -1,8 +1,11 @@
 package com.numble.team3.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.numble.team3.account.resolver.LoginMethodArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -15,5 +18,12 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
     resolvers.add(customMethodArgumentResolver);
+  }
+
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    return objectMapper;
   }
 }

--- a/src/main/java/com/numble/team3/exception/like/LikeNotFoundException.java
+++ b/src/main/java/com/numble/team3/exception/like/LikeNotFoundException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.like;
+
+public class LikeNotFoundException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/like/annotation/AddLikeSwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/AddLikeSwagger.java
@@ -1,0 +1,53 @@
+package com.numble.team3.like.annotation;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiOperation(value = "좋아요 추가")
+@ApiResponses(
+  value = {
+    @ApiResponse(
+      code = 201,
+      message = "좋아요 추가 성공",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{}"))
+    ),
+    @ApiResponse(
+      code = 400,
+      message = "좋아요 추가 실패 \t\n 1. 존재하지 않는 비디오 \t\n 2. 쿼리 파라미터가 존재하지 않음 \t\n 3. 쿼리 파라미터의 타입이 올바르지 않음",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\n\"message\" : \"존재하지 않는 비디오입니다.\"\n\"message\" : \"쿼리 파라미터를 확인해주세요.\"\n\"message\" : \"쿼리 파라미터의 타입을 확인해주세요.\"\n}"))
+    ),
+    @ApiResponse(
+      code = 401,
+      message = "좋아요 추가 실패 \t\n 1. access token이 유효하지 않음",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{}"))
+    )
+  }
+)
+@ApiImplicitParams(
+  value = {
+    @ApiImplicitParam(
+      name = "Authorization",
+      value = "access token",
+      required = true,
+      dataType = "String",
+      paramType = "header"
+    ),
+  }
+)
+@ResponseStatus(HttpStatus.CREATED)
+public @interface AddLikeSwagger {
+
+}

--- a/src/main/java/com/numble/team3/like/annotation/DeleteLikeSwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/DeleteLikeSwagger.java
@@ -1,0 +1,50 @@
+package com.numble.team3.like.annotation;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiOperation(value = "좋아요 삭제")
+@ApiResponses(
+  value = {
+    @ApiResponse(
+      code = 200,
+      message = "좋아요 삭제 성공",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{}"))
+    ),
+    @ApiResponse(
+      code = 400,
+      message = "좋아요 삭제 실패 \t\n 1. 존재하지 않는 좋아요",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\" : \"존재하지 않는 좋아요입니다.\"}"))
+    ),
+    @ApiResponse(
+      code = 401,
+      message = "좋아요 삭제 실패 \t\n 1. access token이 유효하지 않음",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{}"))
+    )
+  }
+)
+@ApiImplicitParams(
+  value = {
+    @ApiImplicitParam(
+      name = "Authorization",
+      value = "access token",
+      required = true,
+      dataType = "String",
+      paramType = "header"
+    ),
+  }
+)
+public @interface DeleteLikeSwagger {
+
+}

--- a/src/main/java/com/numble/team3/like/annotation/GetAllLikesSwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/GetAllLikesSwagger.java
@@ -1,0 +1,45 @@
+package com.numble.team3.like.annotation;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiOperation(value = "관심영상 전체 조회")
+@ApiResponses(
+  value = {
+    @ApiResponse(
+      code = 200,
+      message = "관심영상 조회 성공",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\n\"getLikeDtoList\" : {\n\t \"카테고리 명\" : \n\t \"getLikeDtos\" : [ \n\t\t { \n\t\t \"createdAt\" : \"yyyy-MM-dd HH:mm\", \n\t\t \"getVideoDto\" : { \n\t\t\t \"videoId\" : 비디오 번호, \n\t\t\t \"thumbnailPath\" : \"썸네일 url\", \n\t\t\t \"title\" : \"비디오 이름\", \n\t\t\t \"nickname\" : \"비디오 업로더 닉네임\", \n\t\t\t \"view\" : \"조회수\", \n\t\t\t \"like\" : \"좋아요 수\", \n\t\t\t \"createAd\" : \"yyyy-MM-dd\" \n\t\t } \n\t ], \n\t \"lastLikeId\" : 다음 페이지 요청을 위한 likeId \n}\n}"))
+    ),
+    @ApiResponse(
+      code = 401,
+      message = "관심영상 조회 실패 \t\n 1. access token이 유효하지 않음",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{}"))
+    )
+  }
+)
+@ApiImplicitParams(
+  value = {
+    @ApiImplicitParam(
+      name = "Authorization",
+      value = "access token",
+      required = true,
+      dataType = "String",
+      paramType = "header"
+    ),
+  }
+)
+public @interface GetAllLikesSwagger {
+
+}

--- a/src/main/java/com/numble/team3/like/annotation/GetLikesByCategorySwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/GetLikesByCategorySwagger.java
@@ -1,0 +1,45 @@
+package com.numble.team3.like.annotation;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiOperation(value = "관심영상 카테고리 별 조회")
+@ApiResponses(
+  value = {
+    @ApiResponse(
+      code = 200,
+      message = "관심영상 카테고리 별 조회 성공",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\n\"likes\" : [ \n\t { \n\t\t \"createdAt\" : \"yyyy-MM-dd HH:mm\", \n\t\t \"getVideoDto\" : { \n\t\t\t \"videoId\" : videoId, \n\t\t\t \"thumbnailPath\" : \"썸네일 url\", \n\t\t\t \"title\" : \"title\", \n\t\t\t \"nickname\" : \"비디오 업로더 닉네임\", \n\t\t\t \"view\" : 조회수, \n\t\t\t \"like\" : 좋아요, \n\t\t\t \"createdAt\", \"yyyy-MM-dd\" \n\t\t } \n\t } \n\t], \n \"lastLikeId\" : 다음 페이지 요청을 위한 likeId \n}"))
+    ),
+    @ApiResponse(
+      code = 401,
+      message = "관심영상 조회 실패 \t\n 1. access token이 유효하지 않음",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{}"))
+    )
+  }
+)
+@ApiImplicitParams(
+  value = {
+    @ApiImplicitParam(
+      name = "Authorization",
+      value = "access token",
+      required = true,
+      dataType = "String",
+      paramType = "header"
+    ),
+  }
+)
+public @interface GetLikesByCategorySwagger {
+
+}

--- a/src/main/java/com/numble/team3/like/annotation/GetRankByDaySwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/GetRankByDaySwagger.java
@@ -1,0 +1,27 @@
+package com.numble.team3.like.annotation;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiOperation(value = "일일 랭킹 조회")
+@ApiResponses(
+  value = {
+    @ApiResponse(
+      code = 200,
+      message = "랭킹 조회 성공",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"ranking\" : [ \n\t { \n\t\t \"videoDto\" : { \n\t\t\t \"videoId\" : videoId, \n\t\t\t \"thumbnailPath\" : \"https://thumbnail_url\", \n\t\t\t \"title\" : \"title\", \n\t\t\t \"nickname\" : \"비디오 업로더 닉네임\", \n\t\t\t \"view\" : 조회수, \n\t\t\t \"like\" : 좋아요 수, \n\t\t\t \"createdAt\" : \"yyyy-MM-dd\" \n\t\t } \n\t } \n]\n}"))
+    )
+  }
+)
+public @interface GetRankByDaySwagger {
+
+}

--- a/src/main/java/com/numble/team3/like/application/LikeService.java
+++ b/src/main/java/com/numble/team3/like/application/LikeService.java
@@ -1,0 +1,22 @@
+package com.numble.team3.like.application;
+
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.like.application.response.GetAllLikeListDto;
+import com.numble.team3.like.application.response.GetLikeListDto;
+import com.numble.team3.like.application.response.GetVideoRankDto;
+import java.util.List;
+
+public interface LikeService {
+
+  void addLike(UserInfo userInfo, Long videoId);
+
+  void deleteLike(Long likeId);
+
+  GetLikeListDto getLikesByCategory(UserInfo userInfo, String categoryName, Long likeId, int size);
+
+  GetAllLikeListDto getLikesHierarchy(UserInfo userInfo);
+
+  void rankByDayScheduler(String standard);
+
+  List<GetVideoRankDto> getRank(String standard);
+}

--- a/src/main/java/com/numble/team3/like/application/RedisLikeService.java
+++ b/src/main/java/com/numble/team3/like/application/RedisLikeService.java
@@ -1,0 +1,118 @@
+package com.numble.team3.like.application;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.exception.like.LikeNotFoundException;
+import com.numble.team3.exception.video.VideoNotFoundException;
+import com.numble.team3.like.application.response.GetAllLikeListDto;
+import com.numble.team3.like.application.response.GetLikeCategoryListLimitDto;
+import com.numble.team3.like.application.response.GetLikeDto;
+import com.numble.team3.like.application.response.GetLikeListDto;
+import com.numble.team3.like.application.response.GetVideoRankDto;
+import com.numble.team3.like.domain.Like;
+import com.numble.team3.like.infra.JpaLikeRepository;
+import com.numble.team3.like.infra.LikeRedisUtils;
+import com.numble.team3.video.domain.enums.VideoCategory;
+import com.numble.team3.video.infra.JpaVideoRepository;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RedisLikeService implements LikeService {
+
+  @Value("${like.category.limit}")
+  private int limit;
+
+  private final JpaLikeRepository likeRepository;
+  private final JpaVideoRepository videoRepository;
+  private final LikeRedisUtils likeRedisUtils;
+
+  @Override
+  @Transactional
+  public void addLike(UserInfo userInfo, Long videoId) {
+    likeRepository.save(
+      new Like(videoRepository.findById(videoId).orElseThrow(VideoNotFoundException::new),
+        userInfo.getAccountId()));
+  }
+
+  @Override
+  @Transactional
+  public void deleteLike(Long likeId) {
+    if (!likeRepository.existsById(likeId)) {
+      throw new LikeNotFoundException();
+    }
+
+    likeRepository.deleteById(likeId);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public GetLikeListDto getLikesByCategory(
+    UserInfo userInfo,
+    String categoryName,
+    Long likeId,
+    int size) {
+
+    List<GetLikeDto> likes = likeRepository.getLikesByCategory(userInfo, categoryName, likeId, size);
+
+    if (likes.size() == 0) {
+      return new GetLikeListDto(likes, null);
+    }
+    else {
+      return new GetLikeListDto(likes, likes.get(likes.size() - 1).getId());
+    }
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public GetAllLikeListDto getLikesHierarchy(UserInfo userInfo) {
+    Map<String, List<GetLikeDto>> rankHierarchy = Arrays.stream(VideoCategory.values()).collect(
+      groupingBy(value -> value.getName(), mapping(
+        value -> likeRepository.getAllLikesWithLimit(userInfo.getAccountId(), value, limit)
+          .stream().map(like -> GetLikeDto.fromEntity(like)).collect(toList()),
+        Collector.of(ArrayList::new, List::addAll, (likes, getLikeDto) -> {
+          likes.addAll(getLikeDto);
+          return likes;
+        })
+      )));
+
+    Map<String, GetLikeCategoryListLimitDto> result = rankHierarchy.entrySet().stream()
+      .collect(Collectors.toMap(
+        entry -> entry.getKey(),
+        entry -> {
+          List<GetLikeDto> list = rankHierarchy.get(entry.getKey());
+          if (list.size() == 0) {
+            return new GetLikeCategoryListLimitDto(list, null);
+          } else {
+            return new GetLikeCategoryListLimitDto(list, list.get(list.size() - 1).getId());
+          }
+        }
+      ));
+
+    return new GetAllLikeListDto(result);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public void rankByDayScheduler(String standard) {
+    likeRedisUtils.deleteRanking(standard);
+    likeRedisUtils.saveRanking(likeRepository.getRankingByLikes(), standard);
+  }
+
+  @Override
+  public List<GetVideoRankDto> getRank(String standard) {
+    return likeRedisUtils.getRanking(standard);
+  }
+}

--- a/src/main/java/com/numble/team3/like/application/advice/LikeRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/like/application/advice/LikeRestControllerAdvice.java
@@ -1,0 +1,47 @@
+package com.numble.team3.like.application.advice;
+
+import com.numble.team3.exception.like.LikeNotFoundException;
+import com.numble.team3.exception.video.VideoNotFoundException;
+import com.numble.team3.like.controller.LikeController;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice(assignableTypes = {LikeController.class})
+public class LikeRestControllerAdvice {
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> missingServletRequestParameterException() {
+    return createResponse("쿼리 파라미터를 확인해주세요.");
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> methodArgumentTypeMismatchException() {
+    return createResponse("쿼리 파라미터의 타입을 확인해주세요.");
+  }
+
+  @ExceptionHandler(LikeNotFoundException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> likeNotFoundExceptionHandler() {
+    return createResponse("존재하지 않는 좋아요입니다.");
+  }
+
+  @ExceptionHandler(VideoNotFoundException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> videoNotFoundExceptionHandler() {
+    return createResponse("존재하지 않는 비디오입니다.");
+  }
+
+  private Map<String, String> createResponse(String message) {
+    Map<String, String> response = new HashMap<>();
+    response.put("message", message);
+    return response;
+  }
+}

--- a/src/main/java/com/numble/team3/like/application/response/GetAllLikeListDto.java
+++ b/src/main/java/com/numble/team3/like/application/response/GetAllLikeListDto.java
@@ -1,0 +1,12 @@
+package com.numble.team3.like.application.response;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetAllLikeListDto {
+
+  private Map<String, GetLikeCategoryListLimitDto> likes;
+}

--- a/src/main/java/com/numble/team3/like/application/response/GetLikeCategoryListLimitDto.java
+++ b/src/main/java/com/numble/team3/like/application/response/GetLikeCategoryListLimitDto.java
@@ -1,0 +1,16 @@
+package com.numble.team3.like.application.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetLikeCategoryListLimitDto {
+
+  private List<GetLikeDto> getLikeDtos;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Long lastLikeId;
+}

--- a/src/main/java/com/numble/team3/like/application/response/GetLikeDto.java
+++ b/src/main/java/com/numble/team3/like/application/response/GetLikeDto.java
@@ -1,0 +1,34 @@
+package com.numble.team3.like.application.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.numble.team3.like.domain.Like;
+import com.numble.team3.video.application.response.GetVideoDto;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class GetLikeDto {
+
+  private Long id;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  private LocalDateTime createdAt;
+
+  private GetVideoDto getVideoDto;
+
+  public static GetLikeDto fromEntity(Like like) {
+    return GetLikeDto.builder()
+      .id(like.getId())
+      .createdAt(like.getCreatedAt())
+      .getVideoDto(GetVideoDto.fromEntity(like.getVideo()))
+      .build();
+  }
+}

--- a/src/main/java/com/numble/team3/like/application/response/GetLikeListDto.java
+++ b/src/main/java/com/numble/team3/like/application/response/GetLikeListDto.java
@@ -1,0 +1,17 @@
+package com.numble.team3.like.application.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetLikeListDto {
+
+  private List<GetLikeDto> likes;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Long lastLikeId;
+}
+

--- a/src/main/java/com/numble/team3/like/application/response/GetLikeRankVideoDto.java
+++ b/src/main/java/com/numble/team3/like/application/response/GetLikeRankVideoDto.java
@@ -1,0 +1,41 @@
+package com.numble.team3.like.application.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.numble.team3.video.domain.Video;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class GetLikeRankVideoDto {
+  private Long videoId;
+  private String thumbnailPath;
+  private String title;
+  private String nickname;
+  private long view;
+  private long like;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+  @JsonSerialize(using = LocalDateSerializer.class)
+  private LocalDate createdAt;
+
+  public static GetLikeRankVideoDto fromEntity(Video video) {
+    return GetLikeRankVideoDto.builder()
+      .videoId(video.getId())
+      .thumbnailPath(video.getThumbnailUrl())
+      .title(video.getTitle())
+      .nickname(video.getAccount().getNickname())
+      .view(video.getView())
+      .like(video.getLike())
+      .createdAt(video.getCreateAt().toLocalDate())
+      .build();
+  }
+}

--- a/src/main/java/com/numble/team3/like/application/response/GetVideoQuerydsl.java
+++ b/src/main/java/com/numble/team3/like/application/response/GetVideoQuerydsl.java
@@ -1,0 +1,11 @@
+package com.numble.team3.like.application.response;
+
+import com.numble.team3.video.domain.Video;
+import lombok.Getter;
+
+@Getter
+public class GetVideoQuerydsl {
+
+  private Video video;
+  private long likes;
+}

--- a/src/main/java/com/numble/team3/like/application/response/GetVideoRankDto.java
+++ b/src/main/java/com/numble/team3/like/application/response/GetVideoRankDto.java
@@ -1,0 +1,16 @@
+package com.numble.team3.like.application.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetVideoRankDto {
+
+  private GetLikeRankVideoDto videoDto;
+  private long likes;
+}

--- a/src/main/java/com/numble/team3/like/controller/LikeController.java
+++ b/src/main/java/com/numble/team3/like/controller/LikeController.java
@@ -2,9 +2,15 @@ package com.numble.team3.like.controller;
 
 import com.numble.team3.account.annotation.LoginUser;
 import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.like.annotation.AddLikeSwagger;
+import com.numble.team3.like.annotation.DeleteLikeSwagger;
+import com.numble.team3.like.annotation.GetAllLikesSwagger;
+import com.numble.team3.like.annotation.GetLikesByCategorySwagger;
+import com.numble.team3.like.annotation.GetRankByDaySwagger;
 import com.numble.team3.like.application.LikeService;
 import com.numble.team3.like.application.response.GetAllLikeListDto;
 import com.numble.team3.like.application.response.GetVideoRankDto;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
 import java.util.HashMap;
 import java.util.List;
@@ -23,39 +29,44 @@ import springfox.documentation.annotations.ApiIgnore;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Api(tags = {"관심영상 조회, 랭킹, 좋아요 추가, 좋아요 삭제"})
 public class LikeController {
 
   private final LikeService likeService;
 
+  @AddLikeSwagger
   @PostMapping(value = "/likes/add", produces = "application/json")
   public ResponseEntity addLike(
-    @LoginUser UserInfo userInfo,
-    @RequestParam(name = "id") Long videoId) {
+    @ApiIgnore @LoginUser UserInfo userInfo,
+    @ApiParam(value = "비디오 id", required = true) @RequestParam(name = "id") Long videoId) {
       likeService.addLike(userInfo, videoId);
       return new ResponseEntity(HttpStatus.CREATED);
   }
 
+  @DeleteLikeSwagger
   @DeleteMapping(value = "/likes/delete", produces = "application/json")
-  public ResponseEntity deleteLike(@RequestParam(name = "id") Long likeId) {
+  public ResponseEntity deleteLike(@ApiParam(value = "좋아요 id", required = true) @RequestParam(name = "id") Long likeId) {
     likeService.deleteLike(likeId);
     return new ResponseEntity(HttpStatus.OK);
   }
 
+  @GetAllLikesSwagger
   @GetMapping(value = "/likes/all", produces = "application/json")
-  public ResponseEntity<GetAllLikeListDto> getLikesHierarchy(
-    @LoginUser UserInfo userInfo) {
+  public ResponseEntity<GetAllLikeListDto> getLikesHierarchy(@ApiIgnore @LoginUser UserInfo userInfo) {
     return ResponseEntity.ok(likeService.getLikesHierarchy(userInfo));
   }
 
+  @GetLikesByCategorySwagger
   @GetMapping(value = "/likes", produces = "application/json")
   public ResponseEntity getLikesByCategory(
-    @LoginUser UserInfo userInfo,
-    @RequestParam(name = "category") String categoryName,
-    @RequestParam(required = false, name = "id") Long likeId,
-    @RequestParam(name = "size") int size) {
+    @ApiIgnore @LoginUser UserInfo userInfo,
+    @ApiParam(value = "카테고리 이름", required = true) @RequestParam(name = "category") String categoryName,
+    @ApiParam(value = "like id, 2페이지 이후 조회를 위한 값", required = false) @RequestParam(required = false, name = "id") Long likeId,
+    @ApiParam(value = "페이지 크기", required = true) @RequestParam(name = "size") int size) {
       return ResponseEntity.ok(likeService.getLikesByCategory(userInfo, categoryName, likeId, size));
   }
 
+  @GetRankByDaySwagger
   @GetMapping(value = "/likes/rank/day", produces = "application/json")
   public ResponseEntity<Map> getRankByDay() {
     return new ResponseEntity(new HashMap<String, List<GetVideoRankDto>>() {

--- a/src/main/java/com/numble/team3/like/controller/LikeController.java
+++ b/src/main/java/com/numble/team3/like/controller/LikeController.java
@@ -1,0 +1,67 @@
+package com.numble.team3.like.controller;
+
+import com.numble.team3.account.annotation.LoginUser;
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.like.application.LikeService;
+import com.numble.team3.like.application.response.GetAllLikeListDto;
+import com.numble.team3.like.application.response.GetVideoRankDto;
+import io.swagger.annotations.ApiParam;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class LikeController {
+
+  private final LikeService likeService;
+
+  @PostMapping(value = "/likes/add", produces = "application/json")
+  public ResponseEntity addLike(
+    @LoginUser UserInfo userInfo,
+    @RequestParam(name = "id") Long videoId) {
+      likeService.addLike(userInfo, videoId);
+      return new ResponseEntity(HttpStatus.CREATED);
+  }
+
+  @DeleteMapping(value = "/likes/delete", produces = "application/json")
+  public ResponseEntity deleteLike(@RequestParam(name = "id") Long likeId) {
+    likeService.deleteLike(likeId);
+    return new ResponseEntity(HttpStatus.OK);
+  }
+
+  @GetMapping(value = "/likes/all", produces = "application/json")
+  public ResponseEntity<GetAllLikeListDto> getLikesHierarchy(
+    @LoginUser UserInfo userInfo) {
+    return ResponseEntity.ok(likeService.getLikesHierarchy(userInfo));
+  }
+
+  @GetMapping(value = "/likes", produces = "application/json")
+  public ResponseEntity getLikesByCategory(
+    @LoginUser UserInfo userInfo,
+    @RequestParam(name = "category") String categoryName,
+    @RequestParam(required = false, name = "id") Long likeId,
+    @RequestParam(name = "size") int size) {
+      return ResponseEntity.ok(likeService.getLikesByCategory(userInfo, categoryName, likeId, size));
+  }
+
+  @GetMapping(value = "/likes/rank/day", produces = "application/json")
+  public ResponseEntity<Map> getRankByDay() {
+    return new ResponseEntity(new HashMap<String, List<GetVideoRankDto>>() {
+      {
+        put("ranking", likeService.getRank("day"));
+      }
+    }, HttpStatus.OK);
+  }
+}

--- a/src/main/java/com/numble/team3/like/domain/Like.java
+++ b/src/main/java/com/numble/team3/like/domain/Like.java
@@ -1,0 +1,41 @@
+package com.numble.team3.like.domain;
+
+import com.numble.team3.common.entity.BaseTimeEntity;
+import com.numble.team3.video.domain.Video;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tb_like")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "like_id")
+  private Long id;
+
+  @OneToOne
+  @JoinColumn(name = "video_id")
+  private Video video;
+
+  @Column(name = "account_id")
+  private Long accountId;
+
+  @Builder
+  public Like(Video video, Long accountId) {
+    this.video = video;
+    this.accountId = accountId;
+  }
+}

--- a/src/main/java/com/numble/team3/like/infra/CustomJpaLikeRepository.java
+++ b/src/main/java/com/numble/team3/like/infra/CustomJpaLikeRepository.java
@@ -1,0 +1,12 @@
+package com.numble.team3.like.infra;
+
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.like.application.response.GetLikeDto;
+import com.numble.team3.like.application.response.GetVideoRankDto;
+import java.util.List;
+
+public interface CustomJpaLikeRepository {
+  List<GetLikeDto> getLikesByCategory(UserInfo userInfo, String categoryName, Long likeId, int size);
+
+  List<GetVideoRankDto> getRankingByLikes();
+}

--- a/src/main/java/com/numble/team3/like/infra/CustomJpaLikeRepositoryImpl.java
+++ b/src/main/java/com/numble/team3/like/infra/CustomJpaLikeRepositoryImpl.java
@@ -1,0 +1,97 @@
+package com.numble.team3.like.infra;
+
+import static com.numble.team3.account.domain.QAccount.account;
+import static com.numble.team3.like.domain.QLike.like;
+
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.like.application.response.GetLikeDto;
+import com.numble.team3.like.application.response.GetLikeRankVideoDto;
+import com.numble.team3.like.application.response.GetVideoQuerydsl;
+import com.numble.team3.like.application.response.GetVideoRankDto;
+import com.numble.team3.like.domain.Like;
+import com.numble.team3.video.domain.enums.VideoCategory;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CustomJpaLikeRepositoryImpl implements CustomJpaLikeRepository {
+
+  @Value("${like.category.rank.limit}")
+  private int limit;
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<GetLikeDto> getLikesByCategory(
+    UserInfo userInfo,
+    String categoryName,
+    Long likeId,
+    int size) {
+
+    List<Like> likes = queryFactory.select(like)
+      .from(like)
+      .innerJoin(like.video.account, account)
+      .where(
+        like.accountId.eq(userInfo.getAccountId()),
+        ltLikeId(likeId),
+        like.video.category.eq(VideoCategory.from(categoryName))
+      )
+      .orderBy(like.id.desc())
+      .limit(size)
+      .fetch();
+
+    return likes.stream().map(l -> GetLikeDto.fromEntity(l)).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<GetVideoRankDto> getRankingByLikes() {
+    LocalDate today = LocalDate.now();
+    LocalDate yesterday = today.minusDays(1L);
+
+    List<GetVideoQuerydsl> rank = queryFactory.select(
+        Projections.fields(GetVideoQuerydsl.class,
+          like.video.as("video"),
+          like.id.count().as("likes")
+        ))
+      .from(like)
+      .innerJoin(like.video.account, account).fetchJoin()
+      .where(
+        like.createdAt.goe(yesterday.atStartOfDay()),
+        like.createdAt.lt(today.atStartOfDay())
+      )
+      .groupBy(like.video.id)
+      .having(whereVideoCategory(null))
+      .orderBy(like.id.count().desc(), like.video.id.desc())
+      .limit(limit)
+      .fetch();
+
+    return rank.stream().map(
+      getVideoQuerydsl -> new GetVideoRankDto(GetLikeRankVideoDto.fromEntity(getVideoQuerydsl.getVideo()),
+        getVideoQuerydsl.getLikes())).collect(
+      Collectors.toList());
+  }
+
+  private BooleanExpression whereVideoCategory(VideoCategory videoCategory) {
+    if (videoCategory == null) {
+      return null;
+    }
+
+    return like.video.category.eq(videoCategory);
+  }
+
+  private BooleanExpression ltLikeId(Long likeId) {
+    if (likeId == null) {
+      return null;
+    }
+
+    return like.id.lt(likeId);
+  }
+}

--- a/src/main/java/com/numble/team3/like/infra/JpaLikeRepository.java
+++ b/src/main/java/com/numble/team3/like/infra/JpaLikeRepository.java
@@ -1,0 +1,30 @@
+package com.numble.team3.like.infra;
+
+import com.numble.team3.like.domain.Like;
+import com.numble.team3.video.domain.enums.VideoCategory;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface JpaLikeRepository extends JpaRepository<Like, Long>, CustomJpaLikeRepository {
+
+  boolean existsById(Long likeId);
+
+  @Query("SELECT l FROM Like l JOIN FETCH l.video WHERE l.accountId = :accountId AND l.video.category = :category")
+  List<Like> getAllLikesByAccountIdAndCategory(@Param("accountId") Long accountId,
+    @Param("category") VideoCategory category, Pageable pageable);
+
+  default List<Like> getAllLikesWithLimit(Long accountId, VideoCategory category, int limit) {
+    return getAllLikesByAccountIdAndCategory(accountId, category,
+      PageRequest.of(0, limit, Sort.by("id").descending()));
+  }
+
+  default List<Like> getLikesCategoryWithPaging(Long accountId, VideoCategory category, Pageable pageable) {
+    return getAllLikesByAccountIdAndCategory(accountId, category, pageable);
+  }
+
+}

--- a/src/main/java/com/numble/team3/like/infra/LikeRedisUtils.java
+++ b/src/main/java/com/numble/team3/like/infra/LikeRedisUtils.java
@@ -1,0 +1,50 @@
+package com.numble.team3.like.infra;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numble.team3.like.application.response.GetVideoRankDto;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LikeRedisUtils {
+
+  private final RedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+
+  private static final String PREFIX_KEY = "video::ranking::";
+
+  public void saveRanking(List<GetVideoRankDto> ranking, String standard) {
+    String key = PREFIX_KEY + standard;
+
+    ranking.stream().forEach(rank -> {
+      try {
+        redisTemplate.opsForList().rightPush(key, objectMapper.writeValueAsString(rank));
+      } catch (JsonProcessingException e) {
+        e.printStackTrace();
+      }
+    });
+  }
+
+  public List<GetVideoRankDto> getRanking(String standard) {
+    String key = PREFIX_KEY + standard;
+
+    return ((List<Object>) redisTemplate.opsForList().range(key, 0, 49)).stream().map(video -> {
+      try {
+        return objectMapper.readValue((String) video, GetVideoRankDto.class);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }).collect(Collectors.toList());
+  }
+
+  public void deleteRanking(String standard) {
+    String key = PREFIX_KEY + standard;
+
+    redisTemplate.delete(key);
+  }
+}

--- a/src/main/java/com/numble/team3/like/scheduler/LikeRankScheduler.java
+++ b/src/main/java/com/numble/team3/like/scheduler/LikeRankScheduler.java
@@ -1,0 +1,18 @@
+package com.numble.team3.like.scheduler;
+
+import com.numble.team3.like.application.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LikeRankScheduler {
+
+  private final LikeService likeService;
+
+  @Scheduled(cron = "0 30 0 * * *")
+  protected void rankByDayScheduler() {
+    likeService.rankByDayScheduler("day");
+  }
+}

--- a/src/main/java/com/numble/team3/video/application/response/GetVideoDto.java
+++ b/src/main/java/com/numble/team3/video/application/response/GetVideoDto.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-class GetVideoDto {
+public class GetVideoDto {
   private long videoId;
   private String thumbnailPath;
   private String title;
@@ -39,7 +39,7 @@ class GetVideoDto {
     this.createdAt = createdAt;
   }
 
-  static GetVideoDto fromEntity(Video video) {
+  public static GetVideoDto fromEntity(Video video) {
     return GetVideoDto.builder()
       .videoId(video.getId())
       .thumbnailPath(video.getThumbnailUrl())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,3 +51,9 @@ cloud:
         name: numble-image
       api-gateway:
         url: image-api-gateway-url
+
+like:
+  category:
+    limit: 3
+    rank:
+      limit: 50


### PR DESCRIPTION
## 개요
- #51 
- #40 

## 작업사항
- `Like` 관련 기능을 추가했습니다.
    - `Querydsl`을 사용하기 위해 `config/QuerydslConfig`를 통해 `JPAQueryFactory`를 빈으로 등록했습니다.
    - 중복되는 컬럼인 생성일(`createdAt`)을 공통 처리하기 위해 `common/entity/BaseTimeEntity`를 생성하고 이를 상속받도록 했습니다.
    - #47 에서 접근제어자가 `default`여서 외부에서 접근할 수 없길래 `public`으로 수정했습니다.
    - 관심영상 관련 페이징 처리를 위해 `application.yml`에 값을 추가했습니다.
    - 랭킹을 스케쥴러로 매일 00시 30분에 `redis`에 값을 저장한 이후 조회 시에는 `redis`에서 값을 가져오도록 처리했습니다.
- `Like`에 `Swagger`를 적용시켰습니다.