### PR TITLE
[refactor] account, image, security 설정 수정

### DIFF
--- a/src/main/java/com/numble/team3/account/infra/AccountRedisUtils.java
+++ b/src/main/java/com/numble/team3/account/infra/AccountRedisUtils.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class AccountRedisUtils {
 
   private final RedisTemplate redisTemplate;
-  private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+  private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
   private static final String SEPARATOR = "::";
 

--- a/src/main/java/com/numble/team3/config/SecurityConfig.java
+++ b/src/main/java/com/numble/team3/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       .and()
       .authorizeRequests()
       .antMatchers("/api/sign-in", "/api/sign-up", "/api/refresh-token").permitAll()
+      .antMatchers("/api/likes/rank/day").permitAll()
 
       .anyRequest().authenticated()
 

--- a/src/main/java/com/numble/team3/exception/image/ImageWrongRatioException.java
+++ b/src/main/java/com/numble/team3/exception/image/ImageWrongRatioException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.image;
+
+public class ImageWrongRatioException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/image/annotation/ImageResizeSwagger.java
+++ b/src/main/java/com/numble/team3/image/annotation/ImageResizeSwagger.java
@@ -24,8 +24,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
     ),
     @ApiResponse(
       code = 400,
-      message = "이미지 리사이즈 실패 \t\n 1. 지원하지 않는 이미지 타입 \t\n 2. 지원하지 않는 리사이즈 방식",
-      examples = @Example(@ExampleProperty(mediaType = "application/json", value= "{\n\"message\" : \"지원하지 않는 이미지 파일입니다.\"\n\"message\" : \"지원하지 않는 리사이즈 방식입니다.\"\n}"))
+      message = "이미지 리사이즈 실패 \t\n 1. 지원하지 않는 이미지 타입 \t\n 2. 지원하지 않는 리사이즈 방식 \t\n 3. 이미지 비율이 올바르지 않음",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value= "{\n\"message\" : \"지원하지 않는 이미지 파일입니다.\"\n\"message\" : \"지원하지 않는 리사이즈 방식입니다.\"\n\"message\" : \"잘못된 이미지 비율입니다.\"\n}"))
     ),
     @ApiResponse(
       code = 401,

--- a/src/main/java/com/numble/team3/image/application/advice/ImageRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/image/application/advice/ImageRestControllerAdvice.java
@@ -3,6 +3,7 @@ package com.numble.team3.image.application.advice;
 import com.numble.team3.exception.image.ImageConvertFailureException;
 import com.numble.team3.exception.image.ImageResizeTypeUnSupportException;
 import com.numble.team3.exception.image.ImageTypeUnSupportException;
+import com.numble.team3.exception.image.ImageWrongRatioException;
 import com.numble.team3.image.controller.ImageController;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,6 +33,12 @@ public class ImageRestControllerAdvice {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   Map<String, String> imageTypeUnSupportExceptionHandler() {
     return createResponse("지원하지 않는 이미지 파일입니다.");
+  }
+
+  @ExceptionHandler(ImageWrongRatioException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> imageWrongRatioExceptionHandler() {
+    return createResponse("잘못된 이미지 비율입니다.");
   }
 
   @ExceptionHandler(ImageConvertFailureException.class)

--- a/src/main/java/com/numble/team3/image/controller/ImageController.java
+++ b/src/main/java/com/numble/team3/image/controller/ImageController.java
@@ -1,6 +1,7 @@
 package com.numble.team3.image.controller;
 
 import com.numble.team3.exception.image.ImageResizeTypeUnSupportException;
+import com.numble.team3.exception.image.ImageWrongRatioException;
 import com.numble.team3.image.annotation.ImageResizeSwagger;
 import com.numble.team3.image.application.ImageService;
 import com.numble.team3.image.application.request.CreateImageDto;
@@ -27,14 +28,32 @@ public class ImageController {
   @ImageResizeSwagger
   @PostMapping(value = "/images/resize", produces = "application/json")
   public ResponseEntity<Map> imageResize(@ModelAttribute CreateImageDto dto) throws IOException {
-    if (!(dto.getType().equals("profile") || dto.getType().equals("thumbnail"))) {
-      throw new ImageResizeTypeUnSupportException();
-    }
+    checkResizeType(dto.getType());
+    checkResizeRatio(dto.getType(), Integer.parseInt(dto.getWidth()), Integer.parseInt(dto.getHeight()));
 
     return new ResponseEntity(new HashMap<String, String>() {
       {
         put("url", imageService.uploadResizeImage(dto));
       }
     }, HttpStatus.CREATED);
+  }
+
+  private void checkResizeType(String type) {
+    if (!(type.equals("profile") || type.equals("thumbnail"))) {
+      throw new ImageResizeTypeUnSupportException();
+    }
+  }
+
+  private void checkResizeRatio(String type, int width, int height) {
+    if (type.equals("profile")) {
+      if (width != height) {
+        throw new ImageWrongRatioException();
+      }
+    }
+    else {
+      if ((height * 16) != (width * 9)) {
+        throw new ImageWrongRatioException();
+      }
+    }
   }
 }


### PR DESCRIPTION
## 개요
- 마지막 로그인 날짜 포맷 수정
- 이미지 리사이즈 검증 로직 추가
- 일일 랭킹 

## 작업사항
- `AccountRedisUtils`에서 마지막 로그인 날짜를 `yyyy.MM.dd`로 변경하던 것을 `yyyy-MM-dd`로 수정했습니다.
- 이미지 리사이즈 시 `width`, `height`의 비율을 검증하는 로직을 추가했습니다.
      - `profile`의 비율은 1:1, `thumbnail`의 비율은 16:9임을 검증하도록 했습니다.
      - `ImageWrongRatioException`을 추가했습니다.
- 일일 랭킹의 경우 로그인하지 않은 홈 화면에서도 보여야 하기 때문에 `/api/likes/rank/day`을 `permitAll()`에 추가했습니다.