### PR TITLE
[refactor] ApiGatewayConvertService 이미지 리사이즈 aws 의존성 분리

### DIFF
--- a/src/main/java/com/numble/team3/converter/application/ConvertService.java
+++ b/src/main/java/com/numble/team3/converter/application/ConvertService.java
@@ -7,6 +7,6 @@ import java.io.IOException;
 
 public interface ConvertService {
 
-  String uploadResizeImage(CreateImageDto dto) throws IOException;
+  String uploadResizeImage(CreateImageDto dto);
   GetConvertUrlDto uploadConvertVideo(CreateVideoDto dto) throws IOException;
 }

--- a/src/main/java/com/numble/team3/converter/domain/ConvertImageUtils.java
+++ b/src/main/java/com/numble/team3/converter/domain/ConvertImageUtils.java
@@ -1,0 +1,11 @@
+package com.numble.team3.converter.domain;
+
+import com.numble.team3.converter.application.request.CreateImageDto;
+import java.io.IOException;
+
+public interface ConvertImageUtils {
+
+  String processImageResize(String filename, CreateImageDto dto);
+
+  void saveTempImageFileForMetadata(String filename, CreateImageDto dto) throws IOException;
+}

--- a/src/main/java/com/numble/team3/converter/infra/AwsConvertImageUtils.java
+++ b/src/main/java/com/numble/team3/converter/infra/AwsConvertImageUtils.java
@@ -1,0 +1,78 @@
+package com.numble.team3.converter.infra;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numble.team3.converter.application.request.CreateImageDto;
+import com.numble.team3.converter.domain.ConvertImageUtils;
+import com.numble.team3.exception.convert.ImageConvertFailureException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class AwsConvertImageUtils implements ConvertImageUtils {
+
+  @Value("${cloud.aws.image.s3.name}")
+  private String bucket;
+
+  @Value("${cloud.aws.image.api-gateway.url}")
+  private String apiGateway;
+
+  private final AmazonS3Client amazonS3Client;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public String processImageResize(String filename, CreateImageDto dto) {
+    Map<String, String> params = new HashMap<>(){
+      {
+        put("filename", filename);
+        put("width", dto.getWidth());
+        put("height", dto.getHeight());
+        put("type", dto.getType());
+      }
+    };
+
+    return requestApiGateway("images", params);
+  }
+
+  @Override
+  public void saveTempImageFileForMetadata(String filename, CreateImageDto dto) throws IOException {
+    amazonS3Client.putObject(bucket, filename, dto.getFile().getInputStream(), generateObjectMetaData(dto.getFile()));
+  }
+
+  private String requestApiGateway(String url, Map<String, String> params) {
+    WebClient webClient = WebClient.builder()
+      .baseUrl(apiGateway)
+      .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+      .build();
+
+    String result = webClient.post()
+      .uri(url)
+      .bodyValue(params)
+      .retrieve()
+      .bodyToMono(String.class).block();
+
+    try {
+      Map<String, String> resultMap = objectMapper.readValue(result, Map.class);
+      return resultMap.get("url");
+    } catch (Exception e) {
+      throw new ImageConvertFailureException();
+    }
+  }
+
+  private ObjectMetadata generateObjectMetaData(MultipartFile file) {
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(file.getSize());
+    objectMetadata.setContentType(file.getContentType());
+    return objectMetadata;
+  }
+}


### PR DESCRIPTION
## 개요
- 이미지 리사이즈 aws 의존성 분리

## 작업사항
- 기존에 `ConvertService` 자체에서 관리하던 이미지 관련 aws 의존성을 분리했습니다.
      - 단위 테스트 시 `Mockito`가 `private method`까지 `stubbing`을 지원해주지 않았습니다.
            - `PowerMock`의 경우 의존성 관련 문제가 발생해 사용할 수 없었습니다.
      - 비디오 변환까지 `ApiGatewayConvertService`에서 처리한다면 이미지와 관련된 기능(메타 데이터 추출, 이미지 리사이즈 요청)은 따로 분리하는게 좋다고 판단했습니다.
- `ConvertImageUtils` 인터페이스를 생성하고, 이미지 리사이즈와 관련된 기능을 aws에 의존해서 처리하는 `AwsConvertImageUtils`를 생성했습니다.
- `aws s3` 업로드 시 `IOException`을 단순하게 메소드를 호출한 곳으로 던지는 것이 아닌 커스텀 예외를 던져 `RestControllerAdvice`에서 처리될 수 있도록 했습니다.