### PR TITLE
[feat], [docs] 관리자 회원관리 관련 기능 추가

### DIFF
--- a/src/main/java/com/numble/team3/account/application/AccountService.java
+++ b/src/main/java/com/numble/team3/account/application/AccountService.java
@@ -54,8 +54,6 @@ public class AccountService {
             return dto;
           }).collect(Collectors.toList()))
       .totalCount(accounts.getTotalElements())
-      .hasNext(accounts.hasNext())
-      .hasPrev(accounts.hasPrevious())
       .nowPage(accounts.getNumber() + 1)
       .totalPage(accounts.getTotalPages())
       .size(accounts.getSize())

--- a/src/main/java/com/numble/team3/account/application/AccountService.java
+++ b/src/main/java/com/numble/team3/account/application/AccountService.java
@@ -2,10 +2,17 @@ package com.numble.team3.account.application;
 
 import com.numble.team3.account.domain.Account;
 import com.numble.team3.account.domain.AccountUtils;
-import com.numble.team3.account.infra.AccountRedisHelper;
+import com.numble.team3.account.domain.RoleType;
 import com.numble.team3.account.infra.JpaAccountRepository;
+import com.numble.team3.admin.application.response.GetAccountDetailDto;
+import com.numble.team3.admin.application.response.GetAccountListDto;
+import com.numble.team3.admin.application.response.GetAccountSimpleDto;
+import com.numble.team3.exception.account.AccountNotFoundException;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,5 +39,44 @@ public class AccountService {
         }});
 
     accountIds.stream().forEach(accountId -> accountUtils.deleteAllLastLoginTime(accountId));
+  }
+
+  @Transactional(readOnly = true)
+  public GetAccountListDto getAccounts(PageRequest pageRequest) {
+    Page<Account> accounts = accountRepository.findAllWithAdmin(RoleType.ROLE_USER, false, pageRequest);
+
+    return GetAccountListDto.builder()
+      .accountDtos(
+        accounts.stream().map(
+          account -> {
+            GetAccountSimpleDto dto = GetAccountSimpleDto.fromEntity(account);
+            accountUtils.optionalGetAccountLastLoginTime(account.getId()).ifPresent(lastLogin -> dto.changeLastLogin(lastLogin));
+            return dto;
+          }).collect(Collectors.toList()))
+      .totalCount(accounts.getTotalElements())
+      .hasNext(accounts.hasNext())
+      .hasPrev(accounts.hasPrevious())
+      .nowPage(accounts.getNumber() + 1)
+      .totalPage(accounts.getTotalPages())
+      .size(accounts.getSize())
+      .build();
+  }
+
+  @Transactional(readOnly = true)
+  public GetAccountDetailDto getAccountByAdmin(Long accountId) {
+    GetAccountDetailDto dto =
+      GetAccountDetailDto.fromEntity(accountRepository.findById(accountId)
+        .orElseThrow(AccountNotFoundException::new));
+
+    accountUtils.optionalGetAccountLastLoginTime(dto.getId()).ifPresent(lastLogin -> dto.changeLastLogin(lastLogin));
+
+    return dto;
+  }
+
+  public void withdrawalAccount(Long accountId) {
+    Account account =
+      accountRepository.findById(accountId).orElseThrow(AccountNotFoundException::new);
+
+    account.changeDeleted(true);
   }
 }

--- a/src/main/java/com/numble/team3/account/domain/Account.java
+++ b/src/main/java/com/numble/team3/account/domain/Account.java
@@ -1,6 +1,6 @@
 package com.numble.team3.account.domain;
 
-import com.numble.team3.sign.application.request.SignUpDto;
+import com.numble.team3.common.entity.BaseTimeEntity;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import javax.persistence.Column;
@@ -12,19 +12,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Getter
-@Setter
 @Table(name = "tb_account")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Account {
+public class Account extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/numble/team3/account/domain/AccountUtils.java
+++ b/src/main/java/com/numble/team3/account/domain/AccountUtils.java
@@ -9,7 +9,7 @@ public interface AccountUtils {
 
   String getAccountLastLoginTime(Long accountId);
 
-  Optional<String> optionalGetAccountLastLoginTIme(Long accountId);
+  Optional<String> optionalGetAccountLastLoginTime(Long accountId);
 
   void deleteAllLastLoginTime(Long accountId);
 

--- a/src/main/java/com/numble/team3/account/infra/AccountRedisUtils.java
+++ b/src/main/java/com/numble/team3/account/infra/AccountRedisUtils.java
@@ -23,7 +23,7 @@ public class AccountRedisUtils implements AccountUtils {
   }
 
   @Override
-  public Optional<String> optionalGetAccountLastLoginTIme(Long accountId) {
+  public Optional<String> optionalGetAccountLastLoginTime(Long accountId) {
     return Optional.ofNullable(accountRedisHelper.getLastLogin(accountId));
   }
 

--- a/src/main/java/com/numble/team3/account/infra/JpaAccountRepository.java
+++ b/src/main/java/com/numble/team3/account/infra/JpaAccountRepository.java
@@ -1,8 +1,14 @@
 package com.numble.team3.account.infra;
 
 import com.numble.team3.account.domain.Account;
+import com.numble.team3.account.domain.RoleType;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaAccountRepository extends JpaRepository<Account, Long> {
 
@@ -11,4 +17,7 @@ public interface JpaAccountRepository extends JpaRepository<Account, Long> {
   boolean existsByEmail(String email);
 
   boolean existsByNickname(String nickname);
+
+  @Query("SELECT a FROM Account a WHERE a.roleType = :roleType AND a.deleted = :deleted")
+  Page<Account> findAllWithAdmin(@Param("roleType") RoleType roleType, @Param("deleted") boolean deleted, Pageable pageable);
 }

--- a/src/main/java/com/numble/team3/admin/annotation/DeleteTokenSwagger.java
+++ b/src/main/java/com/numble/team3/admin/annotation/DeleteTokenSwagger.java
@@ -1,0 +1,37 @@
+package com.numble.team3.admin.annotation;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiOperation(value = "토큰 초기화")
+@ApiResponses(
+  value = {
+    @ApiResponse(
+      code = 200,
+      message = "토큰 초기화 성공",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{}"))
+    ),
+    @ApiResponse(
+      code = 401,
+      message = "토큰 초기화 실패 \t\n 1. access token이 유효하지 않음",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{}"))
+    ),
+    @ApiResponse(
+      code = 403,
+      message = "토큰 초기화 실패 \t\n 1. 권한 없음",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{}"))
+    ),
+  }
+)
+public @interface DeleteTokenSwagger {
+
+}

--- a/src/main/java/com/numble/team3/admin/annotation/GetAccountSwagger.java
+++ b/src/main/java/com/numble/team3/admin/annotation/GetAccountSwagger.java
@@ -1,0 +1,42 @@
+package com.numble.team3.admin.annotation;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiOperation(value = "회원 단일 조회")
+@ApiResponses(
+  value = {
+    @ApiResponse(
+      code = 200,
+      message = "회원 단일 조회 성공",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\n\"id\" : account id, \n\"email\" : \"email\", \n\"nickname\" : \"nickname\", \n\"lastLogin\" : \"yyyy-MM-dd\", \n\"createdAt\" : \"yyyy-MM-dd\" \n}"))
+    ),
+    @ApiResponse(
+      code = 400,
+      message = "회원 단일 조회 실패 \t\n 1. 존재하지 않는 회원",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{\"message\" : \"존재하지 않는 회원입니다.\"}"))
+    ),
+    @ApiResponse(
+      code = 401,
+      message = "회원 단일 조회 실패 \t\n 1. access token이 유효하지 않음",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{}"))
+    ),
+    @ApiResponse(
+      code = 403,
+      message = "회원 단일 조회 실패 \t\n 1. 권한 없음",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{}"))
+    ),
+  }
+)
+public @interface GetAccountSwagger {
+
+}

--- a/src/main/java/com/numble/team3/admin/annotation/GetAccountsSwagger.java
+++ b/src/main/java/com/numble/team3/admin/annotation/GetAccountsSwagger.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
     @ApiResponse(
       code = 200,
       message = "회원 목록 조회 성공",
-      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{ \n\"accountDtos\" : [ \n\t { \n\t\t \"id\" : account id, \n\t\t \"email\" : \"email\", \n\t\t \"nickname\" : \"nickname\", \n\t\t \"lastLogin\" : \"yyyy-MM-dd\", \n\t\t \"createdAt\" : \"yyyy-MM-dd\" \n\t } \n\t ], \n\t \"totalCount\" : 전체 회원 수, \n\t \"hasNext\" : 다음 페이지 유무, \n\t \"hasPrev\" : 이전 페이지 유무, \n\t \"nowPage\" : 현재 페이지, \n\t \"totalPage\" : 전체 페이지 , \n\t \"size\" : 페이지 크기 \n}"))
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{ \n\"accountDtos\" : [ \n\t { \n\t\t \"id\" : account id, \n\t\t \"email\" : \"email\", \n\t\t \"nickname\" : \"nickname\", \n\t\t \"lastLogin\" : \"yyyy-MM-dd\", \n\t\t \"createdAt\" : \"yyyy-MM-dd\" \n\t } \n\t ], \n\t \"totalCount\" : 전체 회원 수, \n\t \"nowPage\" : 현재 페이지, \n\t \"totalPage\" : 전체 페이지 , \n\t \"size\" : 페이지 크기 \n}"))
     ),
     @ApiResponse(
       code = 400,

--- a/src/main/java/com/numble/team3/admin/annotation/GetAccountsSwagger.java
+++ b/src/main/java/com/numble/team3/admin/annotation/GetAccountsSwagger.java
@@ -1,0 +1,42 @@
+package com.numble.team3.admin.annotation;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiOperation(value = "회원 목록 조회")
+@ApiResponses(
+  value = {
+    @ApiResponse(
+      code = 200,
+      message = "회원 목록 조회 성공",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{ \n\"accountDtos\" : [ \n\t { \n\t\t \"id\" : account id, \n\t\t \"email\" : \"email\", \n\t\t \"nickname\" : \"nickname\", \n\t\t \"lastLogin\" : \"yyyy-MM-dd\", \n\t\t \"createdAt\" : \"yyyy-MM-dd\" \n\t } \n\t ], \n\t \"totalCount\" : 전체 회원 수, \n\t \"hasNext\" : 다음 페이지 유무, \n\t \"hasPrev\" : 이전 페이지 유무, \n\t \"nowPage\" : 현재 페이지, \n\t \"totalPage\" : 전체 페이지 , \n\t \"size\" : 페이지 크기 \n}"))
+    ),
+    @ApiResponse(
+      code = 400,
+      message = "회원 목록 조회 실패 \t\n 1. 올바르지 않은 페이지 번호",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{\"message\" : \"올바르지 않은 페이지 번호 요청입니다.\"}"))
+    ),
+    @ApiResponse(
+      code = 401,
+      message = "회원 목록 조회 실패 \t\n 1. access token이 유효하지 않음",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{}"))
+    ),
+    @ApiResponse(
+      code = 403,
+      message = "회원 목록 조회 실패 \t\n 1. 권한 없음",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{}"))
+    ),
+  }
+)
+public @interface GetAccountsSwagger {
+
+}

--- a/src/main/java/com/numble/team3/admin/annotation/WithdrawalSwagger.java
+++ b/src/main/java/com/numble/team3/admin/annotation/WithdrawalSwagger.java
@@ -1,0 +1,42 @@
+package com.numble.team3.admin.annotation;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiOperation(value = "회원 강제 탈퇴")
+@ApiResponses(
+  value = {
+    @ApiResponse(
+      code = 200,
+      message = "회원 강제 탈퇴 성공",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{}"))
+    ),
+    @ApiResponse(
+      code = 400,
+      message = "회원 강제 탈퇴 실패 \t\n 1. 존재하지 않는 회원 id",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\" : \"존재하지 않는 회원 id입니다.\"}"))
+    ),
+    @ApiResponse(
+      code = 401,
+      message = "회원 강제 탈퇴 실패 \t\n 1. access token이 유효하지 않음",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{}"))
+    ),
+    @ApiResponse(
+      code = 403,
+      message = "회원 강제 탈퇴 실패 \t\n 1. 권한 없음",
+      examples = @Example(@ExampleProperty(mediaType= "application/json", value = "{}"))
+    ),
+  }
+)
+public @interface WithdrawalSwagger {
+
+}

--- a/src/main/java/com/numble/team3/admin/application/advice/AdminAccountRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/admin/application/advice/AdminAccountRestControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.numble.team3.admin.application.advice;
 
 import com.numble.team3.admin.controller.AdminAccountController;
+import com.numble.team3.exception.account.AccountNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -14,7 +15,13 @@ public class AdminAccountRestControllerAdvice {
   @ExceptionHandler(IllegalArgumentException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   Map<String, String> illegalArgumentExceptionHandler() {
-    return createResponse("잘못된 페이지 요청입니다.");
+    return createResponse("올바르지 않은 페이지 번호 요청입니다.");
+  }
+
+  @ExceptionHandler(AccountNotFoundException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> accountNotFoundExceptionHandler() {
+    return createResponse("존재하지 않는 회원입니다.");
   }
 
   private Map<String, String> createResponse(String message) {

--- a/src/main/java/com/numble/team3/admin/application/advice/AdminAccountRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/admin/application/advice/AdminAccountRestControllerAdvice.java
@@ -1,0 +1,25 @@
+package com.numble.team3.admin.application.advice;
+
+import com.numble.team3.admin.controller.AdminAccountController;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = {AdminAccountController.class})
+public class AdminAccountRestControllerAdvice {
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> illegalArgumentExceptionHandler() {
+    return createResponse("잘못된 페이지 요청입니다.");
+  }
+
+  private Map<String, String> createResponse(String message) {
+    Map<String, String> response = new HashMap<>();
+    response.put("message", message);
+    return response;
+  }
+}

--- a/src/main/java/com/numble/team3/admin/application/response/GetAccountDetailDto.java
+++ b/src/main/java/com/numble/team3/admin/application/response/GetAccountDetailDto.java
@@ -1,0 +1,40 @@
+package com.numble.team3.admin.application.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.numble.team3.account.domain.Account;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetAccountDetailDto {
+
+  private Long id;
+  private String email;
+  private String nickname;
+  private String lastLogin;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  private LocalDateTime createdAt;
+
+  public void changeLastLogin(String lastLogin) {
+    this.lastLogin = lastLogin;
+  }
+
+  public static GetAccountDetailDto fromEntity(Account account) {
+    return GetAccountDetailDto.builder()
+      .id(account.getId())
+      .email(account.getEmail())
+      .nickname(account.getNickname())
+      .lastLogin(account.getLastLogin())
+      .createdAt(account.getCreatedAt())
+      .build();
+  }
+}

--- a/src/main/java/com/numble/team3/admin/application/response/GetAccountListDto.java
+++ b/src/main/java/com/numble/team3/admin/application/response/GetAccountListDto.java
@@ -13,8 +13,6 @@ public class GetAccountListDto {
 
   private List<GetAccountSimpleDto> accountDtos;
   private Long totalCount;
-  private boolean hasNext;
-  private boolean hasPrev;
   private int nowPage;
   private int totalPage;
   private int size;

--- a/src/main/java/com/numble/team3/admin/application/response/GetAccountListDto.java
+++ b/src/main/java/com/numble/team3/admin/application/response/GetAccountListDto.java
@@ -1,0 +1,21 @@
+package com.numble.team3.admin.application.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetAccountListDto {
+
+  private List<GetAccountSimpleDto> accountDtos;
+  private Long totalCount;
+  private boolean hasNext;
+  private boolean hasPrev;
+  private int nowPage;
+  private int totalPage;
+  private int size;
+}

--- a/src/main/java/com/numble/team3/admin/application/response/GetAccountSimpleDto.java
+++ b/src/main/java/com/numble/team3/admin/application/response/GetAccountSimpleDto.java
@@ -1,0 +1,41 @@
+package com.numble.team3.admin.application.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.numble.team3.account.domain.Account;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetAccountSimpleDto {
+
+  private Long id;
+  private String email;
+  private String nickname;
+  private String lastLogin;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  private LocalDateTime createdAt;
+
+  public void changeLastLogin(String lastLogin) {
+    this.lastLogin = lastLogin;
+  }
+
+  public static GetAccountSimpleDto fromEntity(Account account) {
+    return GetAccountSimpleDto.builder()
+      .id(account.getId())
+      .email(account.getEmail())
+      .nickname(account.getNickname())
+      .lastLogin(account.getLastLogin())
+      .createdAt(account.getCreatedAt())
+      .build();
+  }
+}
+

--- a/src/main/java/com/numble/team3/admin/controller/AdminAccountController.java
+++ b/src/main/java/com/numble/team3/admin/controller/AdminAccountController.java
@@ -1,0 +1,53 @@
+package com.numble.team3.admin.controller;
+
+import com.numble.team3.account.application.AccountService;
+import com.numble.team3.sign.application.SignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminAccountController {
+
+  private final AccountService accountService;
+  private final SignService signService;
+
+  @GetMapping(value = "/accounts/all", produces = "application/json")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  public ResponseEntity getAccounts(
+    @RequestParam("page") int page,
+    @RequestParam("size") int size) {
+    return ResponseEntity.ok(accountService.getAccounts(PageRequest.of(page - 1, size)));
+  }
+
+  @GetMapping(value = "/accounts/{id}", produces = "application/json")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  public ResponseEntity getAccount(@PathVariable Long id) {
+    return ResponseEntity.ok(accountService.getAccountByAdmin(id));
+  }
+
+  @DeleteMapping(value = "/accounts/withdrawal/{id}", produces = "application/json")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  public ResponseEntity withdrawalAccount(@PathVariable Long id) {
+    accountService.withdrawalAccount(id);
+    return new ResponseEntity(HttpStatus.OK);
+  }
+
+  @DeleteMapping(value = "/accounts/access-token/{id}", produces = "application/json")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  public ResponseEntity deleteAccessToken(@PathVariable Long id) {
+    signService.deleteToken(id);
+    return new ResponseEntity(HttpStatus.OK);
+  }
+
+}

--- a/src/main/java/com/numble/team3/admin/controller/AdminAccountController.java
+++ b/src/main/java/com/numble/team3/admin/controller/AdminAccountController.java
@@ -1,7 +1,13 @@
 package com.numble.team3.admin.controller;
 
 import com.numble.team3.account.application.AccountService;
+import com.numble.team3.admin.annotation.DeleteTokenSwagger;
+import com.numble.team3.admin.annotation.GetAccountSwagger;
+import com.numble.team3.admin.annotation.GetAccountsSwagger;
+import com.numble.team3.admin.annotation.WithdrawalSwagger;
 import com.numble.team3.sign.application.SignService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -17,25 +23,29 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
+@Api(tags = {"회원 관리"})
 public class AdminAccountController {
 
   private final AccountService accountService;
   private final SignService signService;
 
+  @GetAccountsSwagger
   @GetMapping(value = "/accounts/all", produces = "application/json")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   public ResponseEntity getAccounts(
-    @RequestParam("page") int page,
-    @RequestParam("size") int size) {
+    @ApiParam(value = "페이지", required = true) @RequestParam("page") int page,
+    @ApiParam(value = "페이지 크기", required = true) @RequestParam("size") int size) {
     return ResponseEntity.ok(accountService.getAccounts(PageRequest.of(page - 1, size)));
   }
 
+  @GetAccountSwagger
   @GetMapping(value = "/accounts/{id}", produces = "application/json")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   public ResponseEntity getAccount(@PathVariable Long id) {
     return ResponseEntity.ok(accountService.getAccountByAdmin(id));
   }
 
+  @WithdrawalSwagger
   @DeleteMapping(value = "/accounts/withdrawal/{id}", produces = "application/json")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   public ResponseEntity withdrawalAccount(@PathVariable Long id) {
@@ -43,6 +53,7 @@ public class AdminAccountController {
     return new ResponseEntity(HttpStatus.OK);
   }
 
+  @DeleteTokenSwagger
   @DeleteMapping(value = "/accounts/access-token/{id}", produces = "application/json")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   public ResponseEntity deleteAccessToken(@PathVariable Long id) {

--- a/src/main/java/com/numble/team3/sign/domain/SignUtils.java
+++ b/src/main/java/com/numble/team3/sign/domain/SignUtils.java
@@ -4,13 +4,13 @@ import com.numble.team3.jwt.PrivateClaims;
 
 public interface SignUtils {
 
-  void processSignInRedis(Long accountId, String accessToken, String refreshToken);
+  void processSignIn(Long accountId, String accessToken, String refreshToken);
 
-  void processRefreshValidationRedis(PrivateClaims privateClaims, String refreshToken);
+  void validationRefreshToken(PrivateClaims privateClaims, String refreshToken);
 
-  void processChangeAccessTokenRedis(PrivateClaims privateClaims, String accessToken);
+  void changeAccessToken(PrivateClaims privateClaims, String accessToken);
 
-  void processLogoutRedis(Long accountId);
+  void deleteToken(Long accountId);
 
   void processWithdrawal(Long accountId);
 }

--- a/src/main/java/com/numble/team3/sign/infra/RedisSignUtils.java
+++ b/src/main/java/com/numble/team3/sign/infra/RedisSignUtils.java
@@ -19,14 +19,14 @@ public class RedisSignUtils implements SignUtils {
   private final static String REFRESH_TOKEN_KEY = "refreshToken";
 
   @Override
-  public void processSignInRedis(Long accountId, String accessToken, String refreshToken) {
+  public void processSignIn(Long accountId, String accessToken, String refreshToken) {
     signRedisHelper.saveAccessToken(accountId, accessToken);
     signRedisHelper.saveRefreshToken(accountId, refreshToken);
     accountRedisHelper.saveLastLogin(accountId);
   }
 
   @Override
-  public void processRefreshValidationRedis(PrivateClaims privateClaims, String refreshToken) {
+  public void validationRefreshToken(PrivateClaims privateClaims, String refreshToken) {
     if (!signRedisHelper.validToken(
       refreshToken, REFRESH_TOKEN_KEY, Optional.ofNullable(privateClaims.getAccountId()))) {
       throw new TokenFailureException();
@@ -34,7 +34,7 @@ public class RedisSignUtils implements SignUtils {
   }
 
   @Override
-  public void processChangeAccessTokenRedis(PrivateClaims privateClaims, String accessToken) {
+  public void changeAccessToken(PrivateClaims privateClaims, String accessToken) {
     Long accountId = Long.valueOf(privateClaims.getAccountId());
 
     signRedisHelper.deleteToken(ACCESS_TOKEN_KEY, accountId);
@@ -42,7 +42,7 @@ public class RedisSignUtils implements SignUtils {
   }
 
   @Override
-  public void processLogoutRedis(Long accountId) {
+  public void deleteToken(Long accountId) {
     signRedisHelper.deleteToken(REFRESH_TOKEN_KEY, accountId);
     signRedisHelper.deleteToken(ACCESS_TOKEN_KEY, accountId);
   }


### PR DESCRIPTION
## 개요
- #55
- #40 

## 작업내용
- `admin` 패키지에 관리자 회우너관리 관련 기능을 추가했습니다.
- `AdminAccountController`에 회원 목록 조회, 회원 단일 조회, 토큰 초기화, 회원 탈퇴 기능을 추가했습니다.
- 관련 `Swagger` 작업을 진행했습니다.