### PR TITLE
[refactor] #63 Security, Swagger, Redis 설정 수정

### DIFF
--- a/src/main/java/com/numble/team3/Team3Application.java
+++ b/src/main/java/com/numble/team3/Team3Application.java
@@ -2,10 +2,13 @@ package com.numble.team3;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(
+	exclude = { RedisRepositoriesAutoConfiguration.class }
+)
 @EnableJpaAuditing
 @EnableScheduling
 public class Team3Application {

--- a/src/main/java/com/numble/team3/common/advice/CommonRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/common/advice/CommonRestControllerAdvice.java
@@ -17,6 +17,13 @@ import org.springframework.web.context.request.ServletWebRequest;
 @Slf4j
 public class CommonRestControllerAdvice {
 
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  Map<String, String> exceptionHandler(Exception e) {
+    log.info("", e);
+    return createResponse("예상치 못한 오류가 발생했습니다.");
+  }
+
   @ExceptionHandler(HttpMessageNotReadableException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   Map<String, String> httpMessageNotReadableException() {

--- a/src/main/java/com/numble/team3/config/SecurityConfig.java
+++ b/src/main/java/com/numble/team3/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.numble.team3.security.OAuth2SuccessHandler;
 import com.numble.team3.security.SecurityUtils;
 import com.numble.team3.sign.infra.SignRedisHelper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -27,14 +28,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   private final CustomOAuth2UserService oAuth2UserService;
   private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
-  private static final String[] PERMIT_URL_ARRAY = {
+  private static final String[] SWAGGER_IGNORE_PATH = {
     "/v2/api-docs",
     "/swagger-resources",
     "/swagger-resources/**",
     "/configuration/ui",
     "/configuration/security",
     "/swagger-ui.html",
-    "/webjars/**",
     "/v3/api-docs/**",
     "/swagger-ui/**"
   };
@@ -42,9 +42,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   @Override
   public void configure(WebSecurity web) {
     web.ignoring()
-      .antMatchers("/h2-console/**", "/favicon.ico", "/profile")
-      .antMatchers(PERMIT_URL_ARRAY);
+      .antMatchers("/h2-console/**", "/profile")
+      .antMatchers(SWAGGER_IGNORE_PATH)
+      .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
   }
+
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {

--- a/src/main/java/com/numble/team3/config/SwaggerConfig.java
+++ b/src/main/java/com/numble/team3/config/SwaggerConfig.java
@@ -20,6 +20,7 @@ public class SwaggerConfig implements WebMvcConfigurer {
   @Bean
   public Docket pawsApi() {
     return new Docket(DocumentationType.SWAGGER_2)
+      .useDefaultResponseMessages(false)
       .groupName("Paws API")
       .select()
       .apis(RequestHandlerSelectors.any())

--- a/src/main/java/com/numble/team3/like/annotation/AddLikeSwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/AddLikeSwagger.java
@@ -42,7 +42,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
       name = "Authorization",
       value = "access token",
       required = true,
-      dataType = "String",
+      dataTypeClass = String.class,
       paramType = "header"
     ),
   }

--- a/src/main/java/com/numble/team3/like/annotation/DeleteLikeSwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/DeleteLikeSwagger.java
@@ -40,7 +40,7 @@ import java.lang.annotation.Target;
       name = "Authorization",
       value = "access token",
       required = true,
-      dataType = "String",
+      dataTypeClass = String.class,
       paramType = "header"
     ),
   }

--- a/src/main/java/com/numble/team3/like/annotation/GetAllLikesSwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/GetAllLikesSwagger.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
       name = "Authorization",
       value = "access token",
       required = true,
-      dataType = "String",
+      dataTypeClass = String.class,
       paramType = "header"
     ),
   }

--- a/src/main/java/com/numble/team3/like/annotation/GetLikesByCategorySwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/GetLikesByCategorySwagger.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
       name = "Authorization",
       value = "access token",
       required = true,
-      dataType = "String",
+      dataTypeClass = String.class,
       paramType = "header"
     ),
   }

--- a/src/main/java/com/numble/team3/sign/annotation/CreateAccessTokenSwagger.java
+++ b/src/main/java/com/numble/team3/sign/annotation/CreateAccessTokenSwagger.java
@@ -40,7 +40,7 @@ import java.lang.annotation.Target;
       name = "Cookie",
       value = "refresh token 쿠키",
       required = true,
-      dataType = "String",
+      dataTypeClass = String.class,
       paramType = "body"
     ),
   }


### PR DESCRIPTION
## 개요
- #63 
- `CommenRestControllerAdvice`

## 작업사항
- `SecurityConfig`의 내용을 수정했습니다.
      - `PathRequest.toStaticResources().atCommonLocations()`를 통해 스프링 부트가 제공하는 static 리소스들의 기본위치 모두 조회해 제외했습니다.
      - `Swagger` 설정을 위해 무시하는 배열의 이름을 수정하고, 중복된 부분인 `/webjars/**`를 삭제했습니다.
- `SwaggerConfig`의 내용을 수정했습니다.
      - 자동으로 기본 응답을 만들어주는 설정을 비활성화했습니다.
- `@SpringBootApplication`를 수정했습니다.
      - `Redis`의 경우 `RedisRepository`를 사용하지 않고 `RedisTemplate`만을 사용하기 때문에 `RedisRepositoriesAutoConfiguration`를 제외했습니다.
- `Like`, `Sign`의 `Swagger` 애노테이션을 수정했습니다.
      - `@ApiImplicitParam`의 속성 중 `dataType`을 `dataTypeClass`로 변경했습니다.
- `CommonRestControllerAdvice`에서 모든 예외를 핸들링할 수 있는 메소드를 추가했습니다.