### PR TITLE
[refactor] Account, Admin, Image, Sign 일부 수정

### DIFF
--- a/src/main/java/com/numble/team3/account/annotation/UpdateMyAccountSwagger.java
+++ b/src/main/java/com/numble/team3/account/annotation/UpdateMyAccountSwagger.java
@@ -22,8 +22,8 @@ import java.lang.annotation.Target;
     ),
     @ApiResponse(
       code = 400,
-      message = "회원 정보 수정 실패 \t\n 1. nickname 누락",
-      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\" : \"닉네임을 입력해주세요.\"}"))
+      message = "회원 정보 수정 실패 \t\n 1. nickname 누락 \t\n 2. nickname 중복",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\n\"message\" : \"닉네임을 입력해주세요.\"\n\"message\" : \"이미 존재하는 닉네임입니다.\"\n}"))
     ),
     @ApiResponse(
       code = 401,

--- a/src/main/java/com/numble/team3/account/application/advice/AccountRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/account/application/advice/AccountRestControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.numble.team3.account.application.advice;
 
 import com.numble.team3.account.controller.AccountController;
+import com.numble.team3.exception.account.AccountNicknameAlreadyExistsException;
 import com.numble.team3.exception.account.AccountNotFoundException;
 import com.numble.team3.exception.account.AccountWithdrawalException;
 import java.util.HashMap;
@@ -31,6 +32,12 @@ public class AccountRestControllerAdvice {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   Map<String, String> accountWithdrawalExceptionHandler() {
     return createResponse("이미 탈퇴처리 된 회원입니다.");
+  }
+
+  @ExceptionHandler(AccountNicknameAlreadyExistsException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  Map<String, String> accountNicknameAlreadyExistsExceptionHandler() {
+    return createResponse("이미 존재하는 닉네임입니다.");
   }
 
   private Map<String, String> createResponse(String message) {

--- a/src/main/java/com/numble/team3/account/controller/AccountController.java
+++ b/src/main/java/com/numble/team3/account/controller/AccountController.java
@@ -30,7 +30,7 @@ public class AccountController {
   @GetMyAccountSwagger
   @GetMapping(value = "/accounts", produces = "application/json")
   public ResponseEntity getMyAccount(@ApiIgnore @LoginUser UserInfo userInfo) {
-    return ResponseEntity.ok(accountService.getMyAccount(userInfo));
+    return ResponseEntity.ok(accountService.getAccountByUserInfo(userInfo));
   }
 
   @UpdateMyAccountSwagger
@@ -38,7 +38,7 @@ public class AccountController {
   public ResponseEntity updateMyAccount(
     @ApiIgnore @LoginUser UserInfo userInfo,
     @RequestBody UpdateMyAccountDto dto) {
-    accountService.updateMyAccount(userInfo, dto);
+    accountService.updateAccount(userInfo, dto);
     return new ResponseEntity(HttpStatus.OK);
   }
 

--- a/src/main/java/com/numble/team3/account/infra/JpaAccountRepository.java
+++ b/src/main/java/com/numble/team3/account/infra/JpaAccountRepository.java
@@ -18,6 +18,8 @@ public interface JpaAccountRepository extends JpaRepository<Account, Long> {
 
   boolean existsByNickname(String nickname);
 
+  Optional<Account> findByNickname(String nickname);
+
   @Query("SELECT a FROM Account a WHERE a.roleType = :roleType AND a.deleted = :deleted")
   Page<Account> findAllWithAdmin(@Param("roleType") RoleType roleType, @Param("deleted") boolean deleted, Pageable pageable);
 }

--- a/src/main/java/com/numble/team3/admin/controller/AdminAccountController.java
+++ b/src/main/java/com/numble/team3/admin/controller/AdminAccountController.java
@@ -42,7 +42,7 @@ public class AdminAccountController {
   @GetMapping(value = "/accounts/{id}", produces = "application/json")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   public ResponseEntity getAccount(@PathVariable Long id) {
-    return ResponseEntity.ok(accountService.getAccountByAdmin(id));
+    return ResponseEntity.ok(accountService.getAccountByAccountId(id));
   }
 
   @WithdrawalSwagger

--- a/src/main/java/com/numble/team3/converter/application/request/CreateImageDto.java
+++ b/src/main/java/com/numble/team3/converter/application/request/CreateImageDto.java
@@ -2,6 +2,7 @@ package com.numble.team3.converter.application.request;
 
 import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,7 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class CreateImageDto {
 
   @ApiModelProperty(value = "이미지 파일", required = true)
-  @NotBlank(message = "업로드할 이미지 파일을 선택해주세요.")
+  @NotNull(message = "업로드할 이미지 파일을 선택해주세요.")
   private MultipartFile file;
 
   @ApiModelProperty(value = "리사이즈 가로 길이", required = true)
@@ -19,7 +20,7 @@ public class CreateImageDto {
   private String width;
 
   @ApiModelProperty(value = "리사이즈 세로 길이", required = true)
-  @NotBlank(message = "라사이즈할 세로 길이를 입력해주세요.")
+  @NotBlank(message = "리사이즈할 세로 길이를 입력해주세요.")
   private String height;
 
   @ApiModelProperty(value = "리사이즈 타입(thumbnail / profile)", required = true)

--- a/src/main/java/com/numble/team3/sign/controller/SignController.java
+++ b/src/main/java/com/numble/team3/sign/controller/SignController.java
@@ -49,7 +49,8 @@ public class SignController {
 
   @SignInSwagger
   @PostMapping(value = "/sign-in", produces = "application/json", consumes = "application/json")
-  public ResponseEntity<TokenDto> signIn(@Valid @RequestBody SignInDto dto,
+  public ResponseEntity<TokenDto> signIn(
+    @Valid @RequestBody SignInDto dto,
     HttpServletResponse response) {
     TokenDto token = signService.signIn(dto);
     createCookie(token.getRefreshToken(), 604800, response);
@@ -58,8 +59,9 @@ public class SignController {
   }
 
   @LogoutSwagger
-  @GetMapping(value = "/logout", produces = "application/json", consumes = "application/json")
-  public ResponseEntity logout(@ApiParam(value = "access token", required = true) @RequestHeader(value = "Authorization") String accessToken,
+  @GetMapping(value = "/logout", produces = "application/json")
+  public ResponseEntity logout(
+    @ApiParam(value = "access token", required = true) @RequestHeader(value = "Authorization") String accessToken,
     HttpServletResponse response) {
     signService.logout(accessToken);
     deleteCookie(response);
@@ -68,7 +70,7 @@ public class SignController {
   }
 
   @CreateAccessTokenSwagger
-  @GetMapping(value = "/refresh-token", produces = "application/json", consumes = "application/json")
+  @GetMapping(value = "/refresh-token", produces = "application/json")
   public ResponseEntity createAccessTokenByRefreshToken(HttpServletRequest request) {
     for (Cookie cookie : request.getCookies()) {
       if (cookie.getName().equals("refreshToken")) {
@@ -82,14 +84,14 @@ public class SignController {
   }
 
   @AccountWithdrawalSwagger
-  @DeleteMapping(value = "/withdrawal", produces = "application/json", consumes = "application/json")
+  @DeleteMapping(value = "/withdrawal", produces = "application/json")
   public ResponseEntity accountWithdrawal(
     @ApiParam(value = "access token", required = true) @RequestHeader(value = "Authorization") String accessToken,
     HttpServletResponse response) {
-      signService.withdrawal(accessToken);
-      deleteCookie(response);
+    signService.withdrawal(accessToken);
+    deleteCookie(response);
 
-      return new ResponseEntity(HttpStatus.OK);
+    return new ResponseEntity(HttpStatus.OK);
   }
 
   private void createCookie(String token, int maxAge, HttpServletResponse response) {


### PR DESCRIPTION
## 개요
- `Account` 수정
- `Admin` 수정
- `Image` 수정
- `Sign` 수정

## 작업사항
- 회원 개인정보 수정 시 닉네임 중복체크를 하지 않는 점을 수정했습니다.
      - `JpaAccountRepository`에 `findByNickname()`을 추가했습니다.
      - `AccountService.updateAccount()`에 닉네임 중복체크 로직을 추가했습니다.
      - 관련 `Swagger`도 수정했습니다.
- `AccountService`의 일부 메소드의 이름을 변경했습니다.
      - `AdminAccountController`에서 호출한 메소드 이름이 변경되면서 수정사항이 발생했습니다.
- `CreateImageDto`를 수정했습니다.
      - `message`의 오타를 수정했습니다.
      - `MultipartFile` 타입의 `@Valid`를 `@NotBlank`에서 `@NotNull`로 변경했습니다.
- `SignController`에서 일부 필요없는 `consumes`을 삭제했습니다.
      - 헤더만 요청하거나 쿠키만 요청하는 경우