### PR TITLE
[test] 테스트 코드 추가

### DIFF
--- a/src/test/java/com/numble/team3/account/application/AccountServiceTest.java
+++ b/src/test/java/com/numble/team3/account/application/AccountServiceTest.java
@@ -1,0 +1,234 @@
+package com.numble.team3.account.application;
+
+import static com.numble.team3.factory.dto.AccountDtoFactory.createUpdateMyAccountDto;
+import static com.numble.team3.factory.entity.AccountEntityFactory.createAccount;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.numble.team3.account.application.request.UpdateMyAccountDto;
+import com.numble.team3.account.application.response.GetMyAccountDto;
+import com.numble.team3.account.domain.Account;
+import com.numble.team3.account.domain.AccountUtils;
+import com.numble.team3.account.domain.RoleType;
+import com.numble.team3.account.infra.JpaAccountRepository;
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.admin.application.response.GetAccountDetailDto;
+import com.numble.team3.admin.application.response.GetAccountListDto;
+import com.numble.team3.exception.account.AccountNotFoundException;
+import com.numble.team3.exception.account.AccountWithdrawalException;
+import com.numble.team3.factory.UserInfoFactory;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("AccountService 테스트")
+class AccountServiceTest {
+
+  @Mock
+  JpaAccountRepository accountRepository;
+
+  @Mock
+  AccountUtils accountUtils;
+
+  AccountService accountService;
+
+  @BeforeEach
+  void beforeEach() {
+    accountService = new AccountService(accountRepository, accountUtils);
+  }
+
+  @Test
+  void changeAccountLastLoginByScheduler_성공_테스트() throws Exception {
+    // given
+    Account account =
+      createAccount(1L, "test@email.com", "password", "nickname", RoleType.ROLE_USER);
+
+    given(accountRepository.findAll()).willReturn(List.of(account));
+    given(accountUtils.getAllLastLoginAccountId()).willReturn(List.of(1L));
+    given(accountUtils.getAccountLastLoginTime(anyLong())).willReturn("2022-02-02");
+
+    // when
+    accountService.changeAccountLastLoginByScheduler();
+
+    // then
+    verify(accountUtils).deleteAllLastLoginTime(anyLong());
+  }
+
+  @Test
+  void getAccounts_성공_테스트() throws Exception {
+    // given
+    Account account =
+      createAccount(1L, "test@email.com", "password", "nickname", RoleType.ROLE_USER);
+    Page<Account> accounts = new PageImpl<>(List.of(account));
+    PageRequest pageRequest = PageRequest.of(0, 1);
+
+    given(accountRepository.findAllWithAdmin(any(RoleType.class), anyBoolean(), any(PageRequest.class))).willReturn(accounts);
+
+    // when
+    GetAccountListDto result = accountService.getAccounts(pageRequest);
+
+    // then
+    assertEquals(1, result.getAccountDtos().size());
+    assertEquals(1L, result.getTotalCount());
+    assertEquals(1, result.getNowPage());
+    assertEquals(1, result.getTotalPage());
+    assertEquals(1, result.getSize());
+  }
+
+  @Test
+  void getAccountByAdmin_성공_테스트() throws Exception {
+    // given
+    Account account =
+      createAccount(1L, "test@email.com", "password", "nickname", RoleType.ROLE_USER);
+
+    given(accountRepository.findById(anyLong())).willReturn(Optional.ofNullable(account));
+
+    // when
+    GetAccountDetailDto result = accountService.getAccountByAccountId(1L);
+
+    // then
+    assertEquals(1L, result.getId());
+    assertEquals("test@email.com", result.getEmail());
+    assertEquals("nickname", result.getNickname());
+  }
+
+  @Test
+  void getAccountByAdmin_실패_테스트() {
+    // given
+    given(accountRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(AccountNotFoundException.class, () -> accountService.getAccountByAccountId(1L));
+  }
+
+  @Test
+  void withdrawalAccount_성공_테스트() throws Exception {
+    // given
+    Account account =
+      createAccount(1L, "test@email.com", "password", "nickname", RoleType.ROLE_USER);
+
+    given(accountRepository.findById(anyLong())).willReturn(Optional.ofNullable(account));
+
+    // when
+    accountService.withdrawalAccount(1L);
+
+    // then
+    assertTrue(account.isDeleted());
+  }
+
+  @Test
+  void withdrawalAccount_실패_테스트() {
+    // given
+    given(accountRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(AccountNotFoundException.class, () -> accountService.withdrawalAccount(1L));
+  }
+
+  @Test
+  void getMyAccount_성공_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    Account account =
+      createAccount(1L, "test@email.com", "password", "nickname", RoleType.ROLE_USER);
+
+    given(accountRepository.findById(anyLong())).willReturn(Optional.ofNullable(account));
+
+    // when
+    GetMyAccountDto result = accountService.getAccountByUserInfo(userInfo);
+
+    // then
+    assertEquals("test@email.com", result.getEmail());
+    assertEquals("nickname", result.getNickname());
+  }
+
+  @Test
+  void getMyAccount_없는_회원_실패_테스트() {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(accountRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(AccountNotFoundException.class, () -> accountService.getAccountByUserInfo(userInfo));
+  }
+
+  @Test
+  void getMyAccount_탈퇴_회원_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    Account account =
+      createAccount(1L, "test@email.com", "password", "nickname", RoleType.ROLE_USER);
+    setField(account, "deleted", true);
+
+    given(accountRepository.findById(anyLong())).willReturn(Optional.ofNullable(account));
+
+    // when, then
+    assertThrows(AccountWithdrawalException.class, () -> accountService.getAccountByUserInfo(userInfo));
+  }
+
+  @Test
+  void updateMyAccount_성공_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    Account account =
+      createAccount(1L, "test@email.com", "password", "nickname", RoleType.ROLE_USER);
+    UpdateMyAccountDto dto =
+      createUpdateMyAccountDto(null, "change nickname");
+
+    given(accountRepository.findById(anyLong())).willReturn(Optional.ofNullable(account));
+
+    // when
+    accountService.updateAccount(userInfo, dto);
+
+    // then
+    assertEquals("change nickname", account.getNickname());
+  }
+
+  @Test
+  void updateMyAccount_없는_회원_실패_테스트() {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    UpdateMyAccountDto dto =
+      createUpdateMyAccountDto(null, "change nickname");
+
+    given(accountRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(AccountNotFoundException.class, () -> accountService.updateAccount(userInfo, dto));
+  }
+
+  @Test
+  void updateMyAccount_탈퇴_회원_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    Account account =
+      createAccount(1L, "test@email.com", "password", "nickname", RoleType.ROLE_USER);
+    setField(account, "deleted", true);
+    UpdateMyAccountDto dto =
+      createUpdateMyAccountDto(null, "change nickname");
+
+    given(accountRepository.findById(anyLong())).willReturn(Optional.ofNullable(account));
+
+    // when, then
+    assertThrows(AccountWithdrawalException.class, () -> accountService.updateAccount(userInfo, dto));
+
+  }
+}

--- a/src/test/java/com/numble/team3/account/application/request/UpdateMyAccountDtoTest.java
+++ b/src/test/java/com/numble/team3/account/application/request/UpdateMyAccountDtoTest.java
@@ -1,0 +1,65 @@
+package com.numble.team3.account.application.request;
+
+import static com.numble.team3.factory.dto.AccountDtoFactory.createUpdateMyAccountDto;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("UpdateMyAccountDto Valid 테스트")
+class UpdateMyAccountDtoTest {
+
+  Validator validator;
+
+  @BeforeEach
+  void beforeEach() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  void 검증_성공_테스트() throws Exception {
+    // given
+    UpdateMyAccountDto dto = createUpdateMyAccountDto("profile", "nickname");
+
+    // when
+    Set<ConstraintViolation<UpdateMyAccountDto>> validate = validator.validate(dto);
+
+    // then
+    assertTrue(validate.isEmpty());
+  }
+
+  @Test
+  void nickname_null_실패_테스트() throws Exception {
+    // given
+    UpdateMyAccountDto dto = createUpdateMyAccountDto("profile", null);
+
+    // when
+    ConstraintViolation<UpdateMyAccountDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("닉네임을 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void nickname_nullString_실패_테스트() throws Exception {
+    // given
+    UpdateMyAccountDto dto = createUpdateMyAccountDto("profile", "");
+
+    // when
+    ConstraintViolation<UpdateMyAccountDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("닉네임을 입력해주세요.", result.getMessage());
+  }
+}

--- a/src/test/java/com/numble/team3/account/controller/AccountControllerAdviceTest.java
+++ b/src/test/java/com/numble/team3/account/controller/AccountControllerAdviceTest.java
@@ -1,0 +1,197 @@
+package com.numble.team3.account.controller;
+
+import static com.numble.team3.factory.dto.AccountDtoFactory.createUpdateMyAccountDto;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numble.team3.account.application.AccountService;
+import com.numble.team3.account.application.advice.AccountRestControllerAdvice;
+import com.numble.team3.account.application.request.UpdateMyAccountDto;
+import com.numble.team3.account.domain.RoleType;
+import com.numble.team3.account.resolver.LoginMethodArgumentResolver;
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.exception.account.AccountNicknameAlreadyExistsException;
+import com.numble.team3.exception.account.AccountNotFoundException;
+import com.numble.team3.exception.account.AccountWithdrawalException;
+import com.numble.team3.factory.UserInfoFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("AccountRestControllerAdvice 테스트")
+public class AccountControllerAdviceTest {
+
+  @Mock
+  AccountService accountService;
+
+  @Mock
+  LoginMethodArgumentResolver loginMethodArgumentResolver;
+
+  @InjectMocks
+  AccountController accountController;
+
+  MockMvc mockMvc;
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void beforeEach() {
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(accountController)
+      .setControllerAdvice(new AccountRestControllerAdvice())
+      .setCustomArgumentResolvers(loginMethodArgumentResolver)
+      .addFilter(new CharacterEncodingFilter("UTF-8", true))
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void getMyAccount_없는_회원_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    given(accountService.getAccountByUserInfo(any(UserInfo.class))).willThrow(new AccountNotFoundException());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/accounts/")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
+  }
+
+  @Test
+  void getMyAccount_탈퇴_회원_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    given(accountService.getAccountByUserInfo(any(UserInfo.class))).willThrow(new AccountWithdrawalException());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/accounts/")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("이미 탈퇴처리 된 회원입니다."));
+  }
+
+  @Test
+  void updateMyAccount_없는_회원_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    UpdateMyAccountDto dto = createUpdateMyAccountDto("profile", "nickname");
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    willThrow(new AccountNotFoundException()).given(accountService).updateAccount(any(UserInfo.class), any(UpdateMyAccountDto.class));
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/accounts/update")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto))
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
+  }
+
+  @Test
+  void updateMyAccount_탈퇴_회원_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    UpdateMyAccountDto dto = createUpdateMyAccountDto("profile", "nickname");
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    willThrow(new AccountWithdrawalException()).given(accountService).updateAccount(any(UserInfo.class), any(UpdateMyAccountDto.class));
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/accounts/update")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto))
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("이미 탈퇴처리 된 회원입니다."));
+  }
+
+  @Test
+  void updateMyAccount_nickname_누락_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    UpdateMyAccountDto dto = createUpdateMyAccountDto("profile", "nickname");
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    willThrow(new AccountNicknameAlreadyExistsException()).given(accountService).updateAccount(any(UserInfo.class), any(UpdateMyAccountDto.class));
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/accounts/update")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto))
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isConflict())
+      .andExpect(jsonPath("$.message").value("이미 존재하는 닉네임입니다."));
+  }
+
+  @Test
+  void withdrawalAccount_없는_회원_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    willThrow(new AccountNotFoundException()).given(accountService).withdrawalAccount(anyLong());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/accounts/withdrawal")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
+  }
+}

--- a/src/test/java/com/numble/team3/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/numble/team3/account/controller/AccountControllerTest.java
@@ -1,0 +1,127 @@
+package com.numble.team3.account.controller;
+
+import static com.numble.team3.factory.dto.AccountDtoFactory.createGetMyAccountDto;
+import static com.numble.team3.factory.dto.AccountDtoFactory.createUpdateMyAccountDto;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numble.team3.account.application.AccountService;
+import com.numble.team3.account.application.request.UpdateMyAccountDto;
+import com.numble.team3.account.application.response.GetMyAccountDto;
+import com.numble.team3.account.domain.RoleType;
+import com.numble.team3.account.resolver.LoginMethodArgumentResolver;
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.factory.UserInfoFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("AccountController 테스트")
+class AccountControllerTest {
+
+  @Mock
+  AccountService accountService;
+
+  @Mock
+  LoginMethodArgumentResolver loginMethodArgumentResolver;
+
+  @InjectMocks
+  AccountController accountController;
+
+  MockMvc mockMvc;
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void beforeEach() {
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(accountController)
+      .setCustomArgumentResolvers(loginMethodArgumentResolver)
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void getMyAccount_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    GetMyAccountDto getMyAccountDto =
+      createGetMyAccountDto("test@email.com", null, "nickname");
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    given(accountService.getAccountByUserInfo(any(UserInfo.class))).willReturn(getMyAccountDto);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/accounts")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.email").value("test@email.com"))
+      .andExpect(jsonPath("$.nickname").value("nickname"));
+  }
+
+  @Test
+  void updateMyAccount_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+    UpdateMyAccountDto dto =
+      createUpdateMyAccountDto(null, "change nickname");
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    willDoNothing().given(accountService).updateAccount(any(UserInfo.class), any(UpdateMyAccountDto.class));
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/accounts/update")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto))
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isOk());
+  }
+
+  @Test
+  void withdrawalAccount_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+
+    willDoNothing().given(accountService).withdrawalAccount(anyLong());
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/accounts/withdrawal"));
+
+    // then
+    result
+      .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/com/numble/team3/admin/controller/AdminAccountControllerAdviceTest.java
+++ b/src/test/java/com/numble/team3/admin/controller/AdminAccountControllerAdviceTest.java
@@ -1,0 +1,86 @@
+package com.numble.team3.admin.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.numble.team3.account.application.AccountService;
+import com.numble.team3.admin.application.advice.AdminAccountRestControllerAdvice;
+import com.numble.team3.exception.account.AccountNotFoundException;
+import com.numble.team3.sign.application.SignService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("AdminAccountRestControllerAdvice 테스트")
+public class AdminAccountControllerAdviceTest {
+
+  @Mock
+  AccountService accountService;
+
+  @Mock
+  SignService signService;
+
+  @InjectMocks
+  AdminAccountController adminAccountController;
+
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void beforeEach() {
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(adminAccountController)
+      .setControllerAdvice(new AdminAccountRestControllerAdvice())
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void getAccount_없는_회원_실패_테스트() throws Exception {
+    // given
+    given(accountService.getAccountByAccountId(anyLong())).willThrow(new AccountNotFoundException());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/admin/accounts/{id}", 1)
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
+  }
+
+  @Test
+  void withdrawalAccount_없는_회원_실패_테스트() throws Exception {
+    // given
+    willThrow(new AccountNotFoundException()).given(accountService).withdrawalAccount(anyLong());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/admin/accounts/withdrawal/{id}", 1)
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
+  }
+}

--- a/src/test/java/com/numble/team3/admin/controller/AdminAccountControllerTest.java
+++ b/src/test/java/com/numble/team3/admin/controller/AdminAccountControllerTest.java
@@ -1,0 +1,152 @@
+package com.numble.team3.admin.controller;
+
+import static com.numble.team3.factory.dto.AccountDtoFactory.createGetAccountDetailDto;
+import static com.numble.team3.factory.dto.AccountDtoFactory.createGetAccountListDto;
+import static com.numble.team3.factory.dto.AccountDtoFactory.createGetAccountSimpleDto;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.numble.team3.account.application.AccountService;
+import com.numble.team3.admin.application.response.GetAccountDetailDto;
+import com.numble.team3.admin.application.response.GetAccountListDto;
+import com.numble.team3.admin.application.response.GetAccountSimpleDto;
+import com.numble.team3.sign.application.SignService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("AdminAccountController 테스트")
+class AdminAccountControllerTest {
+
+  @Mock
+  AccountService accountService;
+
+  @Mock
+  SignService signService;
+
+  @InjectMocks
+  AdminAccountController adminAccountController;
+
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void beforeEach() {
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(adminAccountController)
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void getAccounts_테스트() throws Exception {
+    // given
+    PageRequest pageRequest = PageRequest.of(0, 1);
+    GetAccountSimpleDto getAccountSimpleDto =
+      createGetAccountSimpleDto(1L, "test@email.com", "nickname", "2022-02-02");
+    GetAccountListDto getAccountListDto =
+      createGetAccountListDto(List.of(getAccountSimpleDto), pageRequest, 1);
+
+    given(accountService.getAccounts(any(PageRequest.class))).willReturn(getAccountListDto);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/admin//accounts/all")
+        .param("page", "1")
+        .param("size", "3")
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+    );
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.accountDtos").exists())
+      .andExpect(jsonPath("$.accountDtos[0].id").value(1))
+      .andExpect(jsonPath("$.accountDtos[0].email").value("test@email.com"))
+      .andExpect(jsonPath("$.accountDtos[0].nickname").value("nickname"))
+      .andExpect(jsonPath("$.accountDtos[0].lastLogin").value("2022-02-02"))
+      .andExpect(jsonPath("$.accountDtos[0].createdAt").exists())
+      .andExpect(jsonPath("$.totalCount").value(1))
+      .andExpect(jsonPath("$.totalPage").value(1))
+      .andExpect(jsonPath("$.size").value(1));
+  }
+
+  @Test
+  void getAccount_테스트() throws Exception {
+    // given
+    GetAccountDetailDto getAccountDetailDto =
+      createGetAccountDetailDto(1L, "test@email.com", "nickname", "2022-02-02");
+
+    given(accountService.getAccountByAccountId(anyLong())).willReturn(getAccountDetailDto);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/admin/accounts/{id}", 1)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+    );
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.id").value(1))
+      .andExpect(jsonPath("$.email").value("test@email.com"))
+      .andExpect(jsonPath("$.nickname").value("nickname"))
+      .andExpect(jsonPath("$.lastLogin").value("2022-02-02"))
+      .andExpect(jsonPath("$.createdAt").exists());
+  }
+
+  @Test
+  void withdrawalAccount_테스트() throws Exception {
+    // given
+    willDoNothing().given(accountService).withdrawalAccount(anyLong());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/admin/accounts/withdrawal/{id}", 1)
+    );
+
+    // then
+    result
+      .andExpect(status().isOk());
+
+    verify(accountService).withdrawalAccount(anyLong());
+  }
+
+  @Test
+  void deleteAccessToken_테스트() throws Exception {
+    // given
+    willDoNothing().given(signService).deleteToken(anyLong());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/admin/accounts/access-token/{id}", 1)
+    );
+
+    // then
+    result
+      .andExpect(status().isOk());
+
+    verify(signService).deleteToken(anyLong());
+  }
+}

--- a/src/test/java/com/numble/team3/converter/application/ConvertServiceImageTest.java
+++ b/src/test/java/com/numble/team3/converter/application/ConvertServiceImageTest.java
@@ -1,0 +1,79 @@
+package com.numble.team3.converter.application;
+
+import static com.numble.team3.factory.dto.ImageDtoFactory.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+
+import com.numble.team3.converter.application.request.CreateImageDto;
+import com.numble.team3.converter.infra.AwsConvertImageUtils;
+import com.numble.team3.converter.infra.AwsConvertVideoUtils;
+import com.numble.team3.exception.convert.ImageTypeUnSupportException;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("ConvertService 이미지 기능 테스트")
+class ConvertServiceImageTest {
+
+  @Mock
+  AwsConvertImageUtils imageUtils;
+
+  @Mock
+  AwsConvertVideoUtils videoUtils;
+
+  ConvertService convertService;
+
+  @BeforeEach
+  void beforeEach() {
+    convertService = new ApiGatewayConvertService(imageUtils, videoUtils);
+  }
+
+  @Test
+  void uploadResizeImage_성공_테스트() throws IOException {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+    CreateImageDto dto = createImageDto(file, "360", "360", "profile");
+
+    willDoNothing().given(imageUtils).saveTempImageFileForMetadata(anyString(), any(CreateImageDto.class));
+    given(imageUtils.processImageResize(anyString(), any(CreateImageDto.class))).willReturn("파일 url");
+
+    // when
+    String url = convertService.uploadResizeImage(dto);
+
+    // then
+    assertEquals("파일 url", url);
+  }
+
+  @Test
+  void uploadResizeImage_file_타입_미지원_실패_테스트() {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.gif", "image/gif", new byte[]{1});
+    CreateImageDto dto = createImageDto(file, "360", "360", "profile");
+
+    // when, then
+    assertThrows(ImageTypeUnSupportException.class, () -> convertService.uploadResizeImage(dto));
+  }
+
+  @Test
+  void uploadResizeImage_saveTempVideoForConvert_실패_테스트() throws IOException {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.gif", "image/gif", new byte[]{1});
+    CreateImageDto dto = createImageDto(file, "360", "360", "profile");
+
+    // when, then
+    assertThrows(ImageTypeUnSupportException.class, () -> convertService.uploadResizeImage(dto));
+  }
+}

--- a/src/test/java/com/numble/team3/converter/application/request/CreateImageDtoTest.java
+++ b/src/test/java/com/numble/team3/converter/application/request/CreateImageDtoTest.java
@@ -1,0 +1,133 @@
+package com.numble.team3.converter.application.request;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.numble.team3.factory.dto.ImageDtoFactory;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("CreateImageDto Valid 테스트")
+class CreateImageDtoTest {
+
+  Validator validator;
+
+  @BeforeEach
+  void beforeEach() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  void 검증_성공_테스트() {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+    CreateImageDto dto = ImageDtoFactory.createImageDto(file, "360", "360", "profile");
+
+    // when
+    Set<ConstraintViolation<CreateImageDto>> validate = validator.validate(dto);
+
+    // then
+    assertTrue(validate.isEmpty());
+  }
+
+  @Test
+  void file_NotNull_실패_테스트() {
+    // given
+    CreateImageDto dto = ImageDtoFactory.createImageDto(null, "360", "360", "profile");
+
+    // when
+    ConstraintViolation<CreateImageDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("업로드할 이미지 파일을 선택해주세요.", result.getMessage());
+  }
+
+  @Test
+  void width_NotBlank_null_실패_테스트() {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+    CreateImageDto dto = ImageDtoFactory.createImageDto(file, null, "360", "profile");
+
+    // when
+    ConstraintViolation<CreateImageDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("리사이즈할 가로 길이를 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void width_NotBlank_nullString_실패_테스트() {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+    CreateImageDto dto = ImageDtoFactory.createImageDto(file, "", "360", "profile");
+
+    // when
+    ConstraintViolation<CreateImageDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("리사이즈할 가로 길이를 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void height_NotBlank_null_실패_테스트() {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+    CreateImageDto dto = ImageDtoFactory.createImageDto(file, "360", null, "profile");
+
+    // when
+    ConstraintViolation<CreateImageDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("리사이즈할 세로 길이를 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void height_NotBlank_nullString_실패_테스트() {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+    CreateImageDto dto = ImageDtoFactory.createImageDto(file, "360", "", "profile");
+
+    // when
+    ConstraintViolation<CreateImageDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("리사이즈할 세로 길이를 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void type_NotBlank_null_실패_테스트() {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+    CreateImageDto dto = ImageDtoFactory.createImageDto(file, "360", "360", null);
+
+    // when
+    ConstraintViolation<CreateImageDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("리사이즈할 타입을 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void type_NotBlank_nullString_실패_테스트() {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+    CreateImageDto dto = ImageDtoFactory.createImageDto(file, "360", "360", "");
+
+    // when
+    ConstraintViolation<CreateImageDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("리사이즈할 타입을 입력해주세요.", result.getMessage());
+  }
+}

--- a/src/test/java/com/numble/team3/converter/controller/ConvertControllerAdviceTest.java
+++ b/src/test/java/com/numble/team3/converter/controller/ConvertControllerAdviceTest.java
@@ -1,0 +1,86 @@
+package com.numble.team3.converter.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.numble.team3.converter.application.ConvertService;
+import com.numble.team3.converter.application.advice.ConvertRestControllerAdvice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("ConvertRestControllerAdvice 이미지 기능 테스트")
+public class ConvertControllerAdviceTest {
+
+  @Mock
+  ConvertService convertService;
+
+  @InjectMocks
+  ConvertController convertController;
+
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void BeforeEach() {
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(convertController)
+      .setControllerAdvice(new ConvertRestControllerAdvice())
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void imageResize_type_미지원_실패_테스트() throws Exception {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+
+    // when
+    ResultActions result = mockMvc.perform(
+      multipart("/api/images/resize")
+        .file(file)
+        .param("width", "360")
+        .param("height", "360")
+        .param("type", "없는 방식")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("지원하지 않는 리사이즈 방식입니다."));
+  }
+
+  @Test
+  void imageResize_thumbnail_비율_실패_테스트() throws Exception {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+
+    // when
+    ResultActions result = mockMvc.perform(
+      multipart("/api/images/resize")
+        .file(file)
+        .param("width", "360")
+        .param("height", "36")
+        .param("type", "profile")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("잘못된 이미지 비율입니다."));
+  }
+}

--- a/src/test/java/com/numble/team3/converter/controller/ConvertControllerImageTest.java
+++ b/src/test/java/com/numble/team3/converter/controller/ConvertControllerImageTest.java
@@ -1,0 +1,91 @@
+package com.numble.team3.converter.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.numble.team3.converter.application.ConvertService;
+import com.numble.team3.converter.application.request.CreateImageDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("ConvertController 이미지 기능 테스트")
+class ConvertControllerImageTest {
+
+  @Mock
+  ConvertService convertService;
+
+  @InjectMocks
+  ConvertController convertController;
+
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void BeforeEach() {
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(convertController)
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void imageResize_profile_테스트() throws Exception {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+
+    given(convertService.uploadResizeImage(any(CreateImageDto.class))).willReturn("profile url");
+
+    // when
+    ResultActions result = mockMvc.perform(
+      multipart("/api/images/resize")
+        .file(file)
+        .param("width", "360")
+        .param("height", "360")
+        .param("type", "profile")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isCreated())
+      .andExpect(jsonPath("$.url").value("profile url"));
+  }
+
+  @Test
+  void imageResize_thumbnail_테스트() throws Exception {
+    // given
+    MockMultipartFile file = new MockMultipartFile("file", "file.jpeg", "image/jpeg", new byte[]{1});
+
+    given(convertService.uploadResizeImage(any(CreateImageDto.class))).willReturn("thumbnail url");
+
+    // when
+    ResultActions result = mockMvc.perform(
+      multipart("/api/images/resize")
+        .file(file)
+        .param("width", "16")
+        .param("height", "9")
+        .param("type", "thumbnail")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isCreated())
+      .andExpect(jsonPath("$.url").value("thumbnail url"));
+  }
+}

--- a/src/test/java/com/numble/team3/factory/UserInfoFactory.java
+++ b/src/test/java/com/numble/team3/factory/UserInfoFactory.java
@@ -1,0 +1,12 @@
+package com.numble.team3.factory;
+
+import com.numble.team3.account.domain.RoleType;
+import com.numble.team3.account.resolver.UserInfo;
+import java.util.List;
+
+public class UserInfoFactory {
+
+  public static UserInfo createUserInfo(Long accountId, RoleType roleType) {
+    return new UserInfo(accountId, List.of(roleType.toString()));
+  }
+}

--- a/src/test/java/com/numble/team3/factory/dto/AccountDtoFactory.java
+++ b/src/test/java/com/numble/team3/factory/dto/AccountDtoFactory.java
@@ -1,0 +1,52 @@
+package com.numble.team3.factory.dto;
+
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.numble.team3.account.application.request.UpdateMyAccountDto;
+import com.numble.team3.account.application.response.GetMyAccountDto;
+import com.numble.team3.admin.application.response.GetAccountDetailDto;
+import com.numble.team3.admin.application.response.GetAccountListDto;
+import com.numble.team3.admin.application.response.GetAccountSimpleDto;
+import java.lang.reflect.Constructor;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+
+public class AccountDtoFactory {
+
+  public static GetAccountSimpleDto createGetAccountSimpleDto(Long id, String email, String nickname, String lastLogin) throws Exception {
+    Constructor<GetAccountSimpleDto> constructor =
+      GetAccountSimpleDto.class.getDeclaredConstructor(Long.class, String.class, String.class, String.class, LocalDateTime.class);
+    constructor.setAccessible(true);
+
+    return constructor.newInstance(id, email, nickname, lastLogin, LocalDateTime.now());
+  }
+
+  public static GetAccountListDto createGetAccountListDto(List<GetAccountSimpleDto> accounts, PageRequest pageRequest, int totalPage) throws Exception {
+    Constructor<GetAccountListDto> constructor =
+      GetAccountListDto.class.getDeclaredConstructor(List.class, Long.class, int.class, int.class, int.class);
+    constructor.setAccessible(true);
+
+    return constructor.newInstance(accounts, Long.valueOf(accounts.size()), pageRequest.getPageNumber() + 1, totalPage, pageRequest.getPageSize());
+  }
+
+  public static UpdateMyAccountDto createUpdateMyAccountDto(String profile, String nickname) {
+    UpdateMyAccountDto dto = new UpdateMyAccountDto();
+    setField(dto, "profile", profile);
+    setField(dto, "nickname", nickname);
+
+    return dto;
+  }
+
+  public static GetMyAccountDto createGetMyAccountDto(String email, String profile, String nickname) {
+    return new GetMyAccountDto(email, profile, nickname);
+  }
+
+  public static GetAccountDetailDto createGetAccountDetailDto(Long id, String email, String nickname, String lastLogin) throws Exception {
+    Constructor<GetAccountDetailDto> constructor =
+      GetAccountDetailDto.class.getDeclaredConstructor(Long.class, String.class, String.class, String.class, LocalDateTime.class);
+    constructor.setAccessible(true);
+
+    return constructor.newInstance(id, email, nickname, lastLogin, LocalDateTime.now());
+  }
+}

--- a/src/test/java/com/numble/team3/factory/dto/ImageDtoFactory.java
+++ b/src/test/java/com/numble/team3/factory/dto/ImageDtoFactory.java
@@ -1,0 +1,18 @@
+package com.numble.team3.factory.dto;
+
+import com.numble.team3.converter.application.request.CreateImageDto;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ImageDtoFactory {
+
+  public static CreateImageDto createImageDto(MultipartFile file, String width, String height, String type) {
+    CreateImageDto dto = new CreateImageDto();
+
+    dto.setFile(file);
+    dto.setWidth(width);
+    dto.setHeight(height);
+    dto.setType(type);
+
+    return dto;
+  }
+}

--- a/src/test/java/com/numble/team3/factory/dto/LikeDtoFactory.java
+++ b/src/test/java/com/numble/team3/factory/dto/LikeDtoFactory.java
@@ -1,0 +1,67 @@
+package com.numble.team3.factory.dto;
+
+import com.numble.team3.like.application.response.GetAllLikeListDto;
+import com.numble.team3.like.application.response.GetLikeCategoryListLimitDto;
+import com.numble.team3.like.application.response.GetLikeDto;
+import com.numble.team3.like.application.response.GetLikeListDto;
+import com.numble.team3.like.application.response.GetLikeRankVideoDto;
+import com.numble.team3.like.application.response.GetVideoRankDto;
+import com.numble.team3.video.application.response.GetVideoDto;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LikeDtoFactory {
+
+  public static GetLikeDto createGetLikeDto() {
+    GetVideoDto video = GetVideoDto.builder()
+      .videoId(1L)
+      .thumbnailPath("https://thumbnail-url")
+      .title("title")
+      .nickname("nickname")
+      .view(1L)
+      .like(1L)
+      .createdAt(LocalDateTime.now())
+      .build();
+
+    return GetLikeDto.builder()
+      .id(1L)
+      .createdAt(LocalDateTime.now())
+      .getVideoDto(video)
+      .build();
+  }
+
+  public static GetAllLikeListDto createGetAllLikeListDto() {
+    GetLikeDto getLikeDto = createGetLikeDto();
+
+    GetLikeCategoryListLimitDto result
+      = new GetLikeCategoryListLimitDto(List.of(getLikeDto), getLikeDto.getId());
+
+    Map<String, GetLikeCategoryListLimitDto> map = new HashMap<>();
+    map.put("고양이", result);
+
+    return new GetAllLikeListDto(map);
+  }
+
+  public static GetLikeListDto createGetLikeListDto() {
+    GetLikeDto getLikeDto = createGetLikeDto();
+
+    return new GetLikeListDto(List.of(getLikeDto), 1L);
+  }
+
+  public static List<GetVideoRankDto> createGetVideoRankDtoList() {
+    GetLikeRankVideoDto dto = GetLikeRankVideoDto.builder()
+      .videoId(1L)
+      .thumbnailPath("https://thumbnail-url")
+      .title("title")
+      .nickname("nickname")
+      .view(300L)
+      .like(150L)
+      .createdAt(LocalDateTime.now().toLocalDate())
+      .build();
+
+    GetVideoRankDto result = new GetVideoRankDto(dto, 50L);
+    return List.of(result);
+  }
+}

--- a/src/test/java/com/numble/team3/factory/dto/SignDtoFactory.java
+++ b/src/test/java/com/numble/team3/factory/dto/SignDtoFactory.java
@@ -1,0 +1,33 @@
+package com.numble.team3.factory.dto;
+
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.numble.team3.sign.application.request.SignInDto;
+import com.numble.team3.sign.application.request.SignUpDto;
+import java.lang.reflect.Constructor;
+
+public class SignDtoFactory {
+
+  public static SignUpDto createSignUpDto(String email, String password, String nickname) throws Exception {
+    Constructor<SignUpDto> constructor = SignUpDto.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+
+    SignUpDto dto = constructor.newInstance();
+    setField(dto, "email", email);
+    setField(dto, "password", password);
+    setField(dto, "nickname", nickname);
+
+    return dto;
+  }
+
+  public static SignInDto createSignInDto(String email, String password) throws Exception {
+    Constructor<SignInDto> constructor = SignInDto.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+
+    SignInDto dto = constructor.newInstance();
+    setField(dto, "email", email);
+    setField(dto, "password", password);
+
+    return dto;
+  }
+}

--- a/src/test/java/com/numble/team3/factory/entity/AccountEntityFactory.java
+++ b/src/test/java/com/numble/team3/factory/entity/AccountEntityFactory.java
@@ -1,0 +1,31 @@
+package com.numble.team3.factory.entity;
+
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.numble.team3.account.domain.Account;
+import com.numble.team3.account.domain.RoleType;
+import java.lang.reflect.Constructor;
+
+public class AccountEntityFactory {
+
+  public static Account createAccount(Long id, String email, String password, String nickname, RoleType roleType) throws Exception {
+    Constructor<Account> accountConstructor = Account.class.getDeclaredConstructor();
+    accountConstructor.setAccessible(true);
+
+    Account account = accountConstructor.newInstance();
+    setField(account, "id", id);
+    setField(account, "email", email);
+    setField(account, "password", password);
+    setField(account, "nickname", nickname);
+    setField(account, "roleType", roleType);
+
+    return account;
+  }
+
+  public static Account createDeletedAccount(Long id, String email, String password, String nickname, RoleType roleType) throws Exception {
+    Account account = AccountEntityFactory.createAccount(id, email, password, nickname, roleType);
+    setField(account, "deleted", true);
+
+    return account;
+  }
+}

--- a/src/test/java/com/numble/team3/factory/entity/LikeEntityFactory.java
+++ b/src/test/java/com/numble/team3/factory/entity/LikeEntityFactory.java
@@ -1,0 +1,16 @@
+package com.numble.team3.factory.entity;
+
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.numble.team3.like.domain.Like;
+import com.numble.team3.video.domain.Video;
+
+public class LikeEntityFactory {
+
+  public static Like createLike() throws Exception {
+    Video video = VideoEntityFactory.createVideo();
+    Like like = new Like(video, 1L);
+    setField(like, "id", 1L);
+    return like;
+  }
+}

--- a/src/test/java/com/numble/team3/factory/entity/VideoEntityFactory.java
+++ b/src/test/java/com/numble/team3/factory/entity/VideoEntityFactory.java
@@ -1,0 +1,28 @@
+package com.numble.team3.factory.entity;
+
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.numble.team3.account.domain.RoleType;
+import com.numble.team3.video.domain.Video;
+import com.numble.team3.video.domain.enums.VideoCategory;
+
+public class VideoEntityFactory {
+
+  public static Video createVideo() throws Exception {
+    Video video = Video.builder()
+      .videoDuration(360L)
+      .title("title")
+      .content("content")
+      .videoUrl("https://video-url")
+      .thumbnailUrl("https://thumbnail-url")
+      .account(AccountEntityFactory.createAccount(
+        1L, "test@email.com", "1234", "닉네임", RoleType.ROLE_USER))
+      .category(VideoCategory.CAT)
+      .build();
+
+    setField(video, "id", 1L);
+    setField(video, "view", 1L);
+    setField(video, "like", 1L);
+    return video;
+  }
+}

--- a/src/test/java/com/numble/team3/jwt/JwtProviderTest.java
+++ b/src/test/java/com/numble/team3/jwt/JwtProviderTest.java
@@ -1,0 +1,84 @@
+package com.numble.team3.jwt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jsonwebtoken.Claims;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("JwtProvider 테스트")
+public class JwtProviderTest {
+
+  JwtProvider jwtProvider = new JwtProvider();
+
+  @Test
+  void createToken_테스트() {
+    // given
+    String tokenKey = "tokenKey";
+    Map<String, Object> privateClaims = new HashMap<>() {
+      {
+        put("ACCOUNT_ID", 1L);
+        put("ROLE_TYPES", "USER");
+      }
+    };
+    long maxAgeSeconds = 60L;
+
+    // when
+    String token = jwtProvider.createToken(tokenKey, privateClaims, maxAgeSeconds);
+
+    // then
+    assertTrue(token.contains("Bearer"));
+  }
+
+  @Test
+  void parse_성공_테스트() {
+    // given
+    String tokenKey = "tokenKey";
+    Map<String, Object> privateClaims = new HashMap<>() {
+      {
+        put("ACCOUNT_ID", 1L);
+        put("ROLE_TYPES", "USER");
+      }
+    };
+    long maxAgeSeconds = 60L;
+
+    String token = jwtProvider.createToken(tokenKey, privateClaims, maxAgeSeconds);
+
+    // when
+    Optional<Claims> parse = jwtProvider.parse(tokenKey, token);
+
+    // then
+    assertEquals(1L,
+      Long.valueOf(String.valueOf(parse.map(claims -> claims.get("ACCOUNT_ID")).orElseThrow(RuntimeException::new))));
+    assertEquals("USER",
+      String.valueOf(parse.map(claims -> claims.get("ROLE_TYPES")).orElseThrow(RuntimeException::new)));
+  }
+
+  @Test
+  void parse_실패_테스트() {
+    // given
+    String tokenKey = "tokenKey";
+    Map<String, Object> privateClaims = new HashMap<>() {
+      {
+        put("ACCOUNT_ID", 1L);
+        put("ROLE_TYPES", "USER");
+      }
+    };
+    long maxAgeSeconds = 60L;
+
+    String token = jwtProvider.createToken(tokenKey, privateClaims, maxAgeSeconds);
+
+    // when
+    Optional<Claims> parse = jwtProvider.parse(tokenKey, "유효하지 않은 토큰");
+
+    // then
+    assertEquals(Optional.empty(), parse);
+  }
+}

--- a/src/test/java/com/numble/team3/jwt/TokenHelperTest.java
+++ b/src/test/java/com/numble/team3/jwt/TokenHelperTest.java
@@ -1,0 +1,58 @@
+package com.numble.team3.jwt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.numble.team3.account.domain.RoleType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("TokenHelper 테스트")
+public class TokenHelperTest {
+
+  TokenHelper tokenHelper = new TokenHelper(new JwtProvider(), "myKey", 60L);
+  PrivateClaims privateClaims = new PrivateClaims(String.valueOf(1L), List.of(RoleType.ROLE_USER.toString()));
+
+  @Test
+  void createToken_테스트() {
+    // given
+
+    // when
+    String token = tokenHelper.createToken(privateClaims);
+
+    // then
+    assertTrue(token.contains("Bearer "));
+  }
+
+  @Test
+  void parse_성공_테스트() {
+    // given
+    String token = tokenHelper.createToken(privateClaims);
+
+    // when
+    PrivateClaims privateClaims = tokenHelper.parse(token).orElse(null);
+
+    // then
+    assertNotNull(privateClaims);
+    assertEquals(1L, Long.valueOf(privateClaims.getAccountId()));
+    assertEquals("ROLE_USER", privateClaims.getRoleTypes().get(0).toString());
+  }
+
+  @Test
+  void parse_실패_테스트() {
+    // given
+    String token = "유효하지 않은 토큰";
+
+    // when
+    Optional<PrivateClaims> parse = tokenHelper.parse(token);
+
+    // then
+    assertEquals(Optional.empty(), parse);
+  }
+}

--- a/src/test/java/com/numble/team3/like/application/LikeServiceTest.java
+++ b/src/test/java/com/numble/team3/like/application/LikeServiceTest.java
@@ -1,0 +1,185 @@
+package com.numble.team3.like.application;
+
+import static com.numble.team3.factory.UserInfoFactory.createUserInfo;
+import static com.numble.team3.factory.dto.LikeDtoFactory.createGetLikeDto;
+import static com.numble.team3.factory.entity.LikeEntityFactory.createLike;
+import static com.numble.team3.factory.entity.VideoEntityFactory.createVideo;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+
+import com.numble.team3.account.domain.RoleType;
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.exception.like.LikeNotFoundException;
+import com.numble.team3.exception.video.VideoNotFoundException;
+import com.numble.team3.like.application.response.GetAllLikeListDto;
+import com.numble.team3.like.application.response.GetLikeDto;
+import com.numble.team3.like.application.response.GetLikeListDto;
+import com.numble.team3.like.application.response.GetVideoRankDto;
+import com.numble.team3.like.domain.Like;
+import com.numble.team3.like.domain.LikeUtils;
+import com.numble.team3.like.infra.JpaLikeRepository;
+import com.numble.team3.video.domain.Video;
+import com.numble.team3.video.domain.enums.VideoCategory;
+import com.numble.team3.video.infra.JpaVideoRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("LikeService 테스트")
+class LikeServiceTest {
+
+  @Mock
+  JpaLikeRepository likeRepository;
+
+  @Mock
+  JpaVideoRepository videoRepository;
+
+  @Mock
+  LikeUtils likeUtils;
+
+  LikeService likeService;
+
+  @BeforeEach
+  void beforeEach() {
+    likeService = new LikeService(likeRepository, videoRepository, likeUtils);
+  }
+
+  @Test
+  void addLike_성공_테스트() throws Exception {
+    // given
+    Video video = createVideo();
+    UserInfo userInfo = createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(videoRepository.findById(anyLong())).willReturn(Optional.ofNullable(video));
+    given(likeRepository.save(any(Like.class))).willReturn(null);
+
+    // when
+    likeService.addLike(userInfo, 1L);
+
+    // then
+    verify(likeRepository).save(any(Like.class));
+  }
+
+  @Test
+  void addLike_없는_비디오_id_실패_테스트() {
+    // given
+    UserInfo userInfo = createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(videoRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(VideoNotFoundException.class, () -> likeService.addLike(userInfo, 1L));
+  }
+
+  @Test
+  void deleteLike_성공_테스트() {
+    // given
+    given(likeRepository.existsById(anyLong())).willReturn(true);
+
+    // when
+    likeService.deleteLike(1L);
+
+    // then
+    verify(likeRepository).deleteById(anyLong());
+  }
+
+  @Test
+  void deleteLike_없는_좋아요_id_실패_테스트() {
+    // given
+    given(likeRepository.existsById(anyLong())).willThrow(new LikeNotFoundException());
+
+    // when, then
+    assertThrows(LikeNotFoundException.class, () -> likeService.deleteLike(1L));
+  }
+
+  @Test
+  void getLikesByCategory_리스트_없는_성공_테스트() {
+    // given
+    UserInfo userInfo = createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(likeRepository.getLikesByCategory(any(UserInfo.class), anyString(), anyLong(), anyInt()))
+      .willReturn(List.of());
+
+    // when
+    GetLikeListDto result = likeService.getLikesByCategory(userInfo, "카테고리 이름", 1L, 1);
+
+    // then
+    assertEquals(0, result.getLikes().size());
+    assertEquals(null, result.getLastLikeId());
+  }
+
+  @Test
+  void getLikesByCategory_리스트_있는_테스트() throws Exception {
+    // given
+    UserInfo userInfo = createUserInfo(1L, RoleType.ROLE_USER);
+    GetLikeDto dto = createGetLikeDto();
+
+    given(likeRepository.getLikesByCategory(any(UserInfo.class), anyString(), anyLong(), anyInt()))
+      .willReturn(List.of(dto));
+
+    // when
+    GetLikeListDto result = likeService.getLikesByCategory(userInfo, "카테고리 이름", 1L, 1);
+
+    // then
+    assertEquals(1, result.getLikes().size());
+    assertEquals(1L, result.getLastLikeId());
+  }
+
+  @Test
+  void getLikesHierarchy_성공_테스트() throws Exception {
+    // given
+    UserInfo userInfo = createUserInfo(1L, RoleType.ROLE_USER);
+    Like like = createLike();
+
+    given(likeRepository.getAllLikesWithLimit(anyLong(), eq(VideoCategory.CAT), anyInt()))
+      .willReturn(List.of(like));
+
+    // when
+    GetAllLikeListDto result = likeService.getLikesHierarchy(userInfo);
+
+    // then
+    assertEquals(1, result.getLikes().get(VideoCategory.CAT.getName()).getGetLikeDtos().size());
+    assertEquals(1L, result.getLikes().get(VideoCategory.CAT.getName()).getLastLikeId());
+    assertEquals(0, result.getLikes().get(VideoCategory.DOG.getName()).getGetLikeDtos().size());
+  }
+
+  @Test
+  void rankByDayScheduler_성공_테스트() {
+    // given
+    willDoNothing().given(likeUtils).processChangeDayRanking(anyString(), any(List.class));
+
+    // when
+    likeService.rankByDayScheduler("day");
+
+    // then
+    verify(likeUtils).processChangeDayRanking(anyString(), any(List.class));
+  }
+
+  @Test
+  void getRank_성공_테스트() {
+    // given
+    given(likeUtils.getDayRanking(anyString())).willReturn(List.of());
+
+    // when
+    List<GetVideoRankDto> result = likeService.getRank("day");
+
+    // then
+    assertEquals(0, result.size());
+  }
+}

--- a/src/test/java/com/numble/team3/like/controller/LikeControllerAdviceTest.java
+++ b/src/test/java/com/numble/team3/like/controller/LikeControllerAdviceTest.java
@@ -1,0 +1,138 @@
+package com.numble.team3.like.controller;
+
+import static com.numble.team3.factory.UserInfoFactory.createUserInfo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.numble.team3.account.domain.RoleType;
+import com.numble.team3.account.resolver.LoginMethodArgumentResolver;
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.like.application.LikeService;
+import com.numble.team3.like.application.advice.LikeRestControllerAdvice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("LikeRestControllerAdvice 테스트")
+public class LikeControllerAdviceTest {
+
+  @Mock
+  LikeService likeService;
+
+  @Mock
+  LoginMethodArgumentResolver loginMethodArgumentResolver;
+
+  @InjectMocks
+  LikeController likeController;
+
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void beforeEach() {
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(likeController)
+      .setCustomArgumentResolvers(loginMethodArgumentResolver)
+      .setControllerAdvice(new LikeRestControllerAdvice())
+      .addFilter(new CharacterEncodingFilter("UTF-8", true))
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void addLike_파라미터_누락_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/likes/add")
+        .header("Authorization", "Bearer access token")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("쿼리 파라미터를 확인해주세요."));
+  }
+
+  @Test
+  void deleteLike_파라미터_누락_실패_테스트() throws Exception {
+    // given
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/likes/delete")
+        .header("Authorization", "Bearer access token")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("쿼리 파라미터를 확인해주세요."));
+  }
+
+  @Test
+  void getLikesByCategory_카테고리_파라미터_누락_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/likes/")
+        .param("size", "3")
+        .header("Authorization", "access token")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("쿼리 파라미터를 확인해주세요."));
+  }
+
+  @Test
+  void getLikesByCategory_size_파라미터_누락_실패_테스트() throws Exception {
+    // given
+    UserInfo userInfo = createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/likes/")
+        .param("category", "cat")
+        .header("Authorization", "access token")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("쿼리 파라미터를 확인해주세요."));
+  }
+}
+

--- a/src/test/java/com/numble/team3/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/numble/team3/like/controller/LikeControllerTest.java
@@ -1,0 +1,212 @@
+package com.numble.team3.like.controller;
+
+import static com.numble.team3.factory.dto.LikeDtoFactory.createGetAllLikeListDto;
+import static com.numble.team3.factory.dto.LikeDtoFactory.createGetLikeListDto;
+import static com.numble.team3.factory.dto.LikeDtoFactory.createGetVideoRankDtoList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.numble.team3.account.domain.RoleType;
+import com.numble.team3.account.resolver.LoginMethodArgumentResolver;
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.factory.UserInfoFactory;
+import com.numble.team3.like.application.LikeService;
+import com.numble.team3.like.application.response.GetAllLikeListDto;
+import com.numble.team3.like.application.response.GetLikeListDto;
+import com.numble.team3.like.application.response.GetVideoRankDto;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("LikeController 테스트")
+class LikeControllerTest {
+
+  @Mock
+  LikeService likeService;
+
+  @Mock
+  LoginMethodArgumentResolver loginMethodArgumentResolver;
+
+  @InjectMocks
+  LikeController likeController;
+
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void beforeEach() {
+
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(likeController)
+      .setCustomArgumentResolvers(loginMethodArgumentResolver)
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void addLike_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    willDoNothing().given(likeService).addLike(any(UserInfo.class), anyLong());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/likes/add").param("id", "1")
+        .header("Authorization", "Bearer access token")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isCreated());
+
+    verify(likeService).addLike(any(UserInfo.class), anyLong());
+  }
+
+  @Test
+  void deleteLike_테스트() throws Exception {
+    // given
+    willDoNothing().given(likeService).deleteLike(anyLong());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/likes/delete").param("id", "1")
+        .header("Authorization", "access token")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isOk());
+
+    verify(likeService).deleteLike(anyLong());
+  }
+
+  @Test
+  void getLikesHierarchy_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+
+    GetAllLikeListDto dto = createGetAllLikeListDto();
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    given(likeService.getLikesHierarchy(any(UserInfo.class))).willReturn(dto);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/likes/all")
+        .header("Authorization", "access token")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.likes").exists())
+      .andExpect(jsonPath("$.likes.고양이").exists())
+      .andExpect(jsonPath("$.likes.고양이.lastLikeId").value(1))
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos").exists())
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0]").exists())
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].id").value(1))
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].createdAt").exists())
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].getVideoDto").exists())
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].getVideoDto.videoId").value(1))
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].getVideoDto.thumbnailPath").value("https://thumbnail-url"))
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].getVideoDto.title").value("title"))
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].getVideoDto.nickname").value("nickname"))
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].getVideoDto.view").value(1))
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].getVideoDto.like").value(1))
+      .andExpect(jsonPath("$.likes.고양이.getLikeDtos[0].getVideoDto.createdAt").exists());
+
+    verify(likeService).getLikesHierarchy(any(UserInfo.class));
+  }
+
+  @Test
+  void getLikesByCategory_테스트() throws Exception {
+    // given
+    UserInfo userInfo = UserInfoFactory.createUserInfo(1L, RoleType.ROLE_USER);
+
+    GetLikeListDto dto = createGetLikeListDto();
+
+    given(loginMethodArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginMethodArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(userInfo);
+    given(likeService.getLikesByCategory(any(UserInfo.class), anyString(), any(), anyInt()))
+      .willReturn(dto);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/likes/")
+        .param("category", "cat")
+        .param("size", "3")
+        .header("Authorization", "access token")
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.lastLikeId").value(1))
+      .andExpect(jsonPath("$.likes").exists())
+      .andExpect(jsonPath("$.likes[0].id").value(1))
+      .andExpect(jsonPath("$.likes[0].createdAt").exists())
+      .andExpect(jsonPath("$.likes[0].getVideoDto").exists())
+      .andExpect(jsonPath("$.likes[0].getVideoDto.videoId").value(1))
+      .andExpect(jsonPath("$.likes[0].getVideoDto.thumbnailPath").value("https://thumbnail-url"))
+      .andExpect(jsonPath("$.likes[0].getVideoDto.title").value("title"))
+      .andExpect(jsonPath("$.likes[0].getVideoDto.nickname").value("nickname"))
+      .andExpect(jsonPath("$.likes[0].getVideoDto.view").value(1))
+      .andExpect(jsonPath("$.likes[0].getVideoDto.like").value(1))
+      .andExpect(jsonPath("$.likes[0].getVideoDto.createdAt").exists());
+
+    verify(likeService).getLikesByCategory(any(UserInfo.class), anyString(), any(), anyInt());
+  }
+
+  @Test
+  void getRankByDay_테스트() throws Exception {
+    // given
+    List<GetVideoRankDto> dto = createGetVideoRankDtoList();
+
+    given(likeService.getRank(anyString())).willReturn(dto);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/likes/rank/day"));
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.ranking").exists())
+      .andExpect(jsonPath("$.ranking[0].videoDto").exists())
+      .andExpect(jsonPath("$.ranking[0].likes").value(50))
+      .andExpect(jsonPath("$.ranking[0].videoDto.videoId").value(1))
+      .andExpect(jsonPath("$.ranking[0].videoDto.thumbnailPath").value("https://thumbnail-url"))
+      .andExpect(jsonPath("$.ranking[0].videoDto.title").value("title"))
+      .andExpect(jsonPath("$.ranking[0].videoDto.nickname").value("nickname"))
+      .andExpect(jsonPath("$.ranking[0].videoDto.view").value(300))
+      .andExpect(jsonPath("$.ranking[0].videoDto.like").value(150))
+      .andExpect(jsonPath("$.ranking[0].videoDto.createdAt").exists());
+  }
+}

--- a/src/test/java/com/numble/team3/sign/application/SignServiceTest.java
+++ b/src/test/java/com/numble/team3/sign/application/SignServiceTest.java
@@ -1,0 +1,266 @@
+package com.numble.team3.sign.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.numble.team3.account.domain.Account;
+import com.numble.team3.account.domain.RoleType;
+import com.numble.team3.account.infra.JpaAccountRepository;
+import com.numble.team3.exception.account.AccountEmailAlreadyExistsException;
+import com.numble.team3.exception.account.AccountNicknameAlreadyExistsException;
+import com.numble.team3.exception.account.AccountNotFoundException;
+import com.numble.team3.exception.account.AccountWithdrawalException;
+import com.numble.team3.exception.sign.SignInFailureException;
+import com.numble.team3.exception.sign.TokenFailureException;
+import com.numble.team3.factory.dto.SignDtoFactory;
+import com.numble.team3.factory.entity.AccountEntityFactory;
+import com.numble.team3.jwt.PrivateClaims;
+import com.numble.team3.jwt.TokenHelper;
+import com.numble.team3.sign.application.request.SignInDto;
+import com.numble.team3.sign.application.request.SignUpDto;
+import com.numble.team3.sign.application.response.TokenDto;
+import com.numble.team3.sign.domain.SignUtils;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("SignService 테스트")
+class SignServiceTest {
+
+  @Mock
+  JpaAccountRepository accountRepository;
+
+  @Mock
+  PasswordEncoder passwordEncoder;
+
+  @Mock
+  TokenHelper accessTokenHelper;
+
+  @Mock
+  TokenHelper refreshTokenHelper;
+
+  @Mock
+  SignUtils signUtils;
+
+  SignService signService;
+
+  @BeforeEach
+  void beforeEach() {
+    signService =
+      new SignService(accountRepository, passwordEncoder, accessTokenHelper, refreshTokenHelper, signUtils);
+  }
+
+  @Test
+  void signUp_성공_테스트() throws Exception {
+    // given
+    SignUpDto dto =
+      SignDtoFactory.createSignUpDto("test@email.com", "1234", "닉네임");
+
+    // when
+    signService.signUp(dto);
+
+    // then
+    verify(accountRepository).save(any(Account.class));
+  }
+
+  @Test
+  void signUp_이메일_중복_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto =
+      SignDtoFactory.createSignUpDto("중복 이메일@email.com", "1234", "닉네임");
+
+    given(accountRepository.existsByEmail(anyString())).willReturn(true);
+
+    // when, then
+    assertThrows(AccountEmailAlreadyExistsException.class, () -> signService.signUp(dto));
+  }
+
+  @Test
+  void signUp_닉네임_중복_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto =
+      SignDtoFactory.createSignUpDto("test@email.com", "1234", "중복 닉네임");
+
+    given(accountRepository.existsByEmail(anyString())).willReturn(false);
+    given(accountRepository.existsByNickname(anyString())).willReturn(true);
+
+    // when, then
+    assertThrows(AccountNicknameAlreadyExistsException.class, () -> signService.signUp(dto));
+  }
+
+  @Test
+  void signIn_성공_테스트() throws Exception {
+    // given
+    Account account =
+      AccountEntityFactory.createAccount(
+        1L, "test@email.com", "1234", "닉네임", RoleType.ROLE_USER);
+    SignInDto dto = SignDtoFactory.createSignInDto("test@email.com", "1234");
+
+    given(accountRepository.findByEmail(anyString())).willReturn(Optional.ofNullable(account));
+    given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+    given(accessTokenHelper.createToken(any())).willReturn("accessToken");
+    given(refreshTokenHelper.createToken(any())).willReturn("refreshToken");
+
+    // when
+    TokenDto token = signService.signIn(dto);
+
+    // then
+    assertEquals("accessToken", token.getAccessToken());
+    assertEquals("refreshToken", token.getRefreshToken());
+
+    verify(signUtils).processSignIn(anyLong(), anyString(), anyString());
+  }
+
+  @Test
+  void signIn_없는_이메일_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = SignDtoFactory.createSignInDto("없는 이메일@email.com", "1234");
+
+    given(accountRepository.findByEmail(anyString())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(SignInFailureException.class, () -> signService.signIn(dto));
+  }
+
+  @Test
+  void signIn_일치하지_않는_비밀번호_실패_테스트() throws Exception {
+    // given
+    Account account =
+      AccountEntityFactory.createAccount(
+        1L, "test@email.com", "1234", "닉네임", RoleType.ROLE_USER);
+    SignInDto dto = SignDtoFactory.createSignInDto("없는 이메일@email.com", "다른 비밀번호");
+
+    given(accountRepository.findByEmail(anyString())).willReturn(Optional.ofNullable(account));
+    given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+    // when, then
+    assertThrows(SignInFailureException.class, () -> signService.signIn(dto));
+  }
+
+  @Test
+  void signIn_탈퇴한_회원_실패_테스트() throws Exception {
+    // given
+    Account account =
+      AccountEntityFactory.createDeletedAccount(
+        1L, "test@email.com", "1234", "닉네임", RoleType.ROLE_USER);
+    SignInDto dto = SignDtoFactory.createSignInDto("test@email.com", "1234");
+
+    given(accountRepository.findByEmail(anyString())).willReturn(Optional.ofNullable(account));
+
+    // when, then
+    assertThrows(AccountWithdrawalException.class, () -> signService.signIn(dto));
+  }
+
+  @Test
+  void createAccessTokenByRefreshToken_성공_테스트() {
+    // given
+    String refreshToken = "refreshToken";
+    PrivateClaims privateClaims =
+      new PrivateClaims(String.valueOf(1L), List.of(RoleType.ROLE_USER.toString()));
+
+    given(refreshTokenHelper.parse(anyString())).willReturn(Optional.ofNullable(privateClaims));
+    given(accessTokenHelper.createToken(any())).willReturn("new accessToken");
+
+    // when
+    TokenDto token = signService.createAccessTokenByRefreshToken(refreshToken);
+
+    // then
+    assertEquals("new accessToken", token.getAccessToken());
+
+    verify(signUtils).changeAccessToken(any(PrivateClaims.class), anyString());
+  }
+
+  @Test
+  void createAccessTokenByRefreshToken_refreshToken_만료_실패_테스트() {
+    // given
+    given(refreshTokenHelper.parse(anyString())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(TokenFailureException.class, () -> signService.createAccessTokenByRefreshToken("만료된 토큰"));
+  }
+
+  @Test
+  void logout_성공_테스트() {
+    // given
+    String accessToken = "accessToken";
+    PrivateClaims privateClaims =
+      new PrivateClaims(String.valueOf(1L), List.of(RoleType.ROLE_USER.toString()));
+
+    given(accessTokenHelper.parse(anyString())).willReturn(Optional.ofNullable(privateClaims));
+
+    // when
+    signService.logout(accessToken);
+
+    // then
+    signUtils.deleteToken(anyLong());
+  }
+
+  @Test
+  void logout_만료된_토큰_실패_테스트() {
+    // given
+    given(accessTokenHelper.parse(anyString())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(TokenFailureException.class, () -> signService.logout("만료된 토큰"));
+  }
+
+  @Test
+  void withdrawal_성공_테스트() throws Exception {
+    // given
+    String accessToken = "accessToken";
+    PrivateClaims privateClaims =
+      new PrivateClaims(String.valueOf(1L), List.of(RoleType.ROLE_USER.toString()));
+    Account account =
+      AccountEntityFactory.createAccount(
+        1L, "test@email.com", "1234", "닉네임", RoleType.ROLE_USER);
+
+    given(accessTokenHelper.parse(anyString())).willReturn(Optional.ofNullable(privateClaims));
+    given(accountRepository.findById(anyLong())).willReturn(Optional.ofNullable(account));
+
+    // when
+    signService.withdrawal(accessToken);
+
+    // then
+    assertEquals(true, account.isDeleted());
+
+    verify(signUtils).processWithdrawal(anyLong());
+  }
+
+  @Test
+  void withdrawal_토큰_만료_실패_테스트() {
+    // given
+    given(accessTokenHelper.parse(anyString())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(TokenFailureException.class, () -> signService.withdrawal("만료된 토큰"));
+  }
+
+  @Test
+  void withdrawal_없는_이메일_실패_테스트() throws Exception {
+    // given
+    String accessToken = "accessToken";
+    PrivateClaims privateClaims =
+      new PrivateClaims(String.valueOf(1L), List.of(RoleType.ROLE_USER.toString()));
+    SignInDto dto = SignDtoFactory.createSignInDto("없는 이메일@email.com", "1234");
+
+    given(accessTokenHelper.parse(anyString())).willReturn(Optional.ofNullable(privateClaims));
+    given(accountRepository.findById(anyLong())).willReturn(Optional.empty());
+
+    // when, then
+    assertThrows(AccountNotFoundException.class, () -> signService.withdrawal(accessToken));
+  }
+}

--- a/src/test/java/com/numble/team3/sign/application/request/SignInDtoTest.java
+++ b/src/test/java/com/numble/team3/sign/application/request/SignInDtoTest.java
@@ -1,0 +1,101 @@
+package com.numble.team3.sign.application.request;
+
+import static com.numble.team3.factory.dto.SignDtoFactory.createSignInDto;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("SignInDto Valid 테스트")
+class SignInDtoTest {
+
+  Validator validator;
+
+  @BeforeEach
+  void beforeEach() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  void 검증_성공_테스트() throws Exception {
+    // given
+    SignInDto dto = createSignInDto("test@email.com", "1234");
+
+    // when
+    Set<ConstraintViolation<SignInDto>> validate = validator.validate(dto);
+
+    // then
+    assertTrue(validate.isEmpty());
+  }
+
+  @Test
+  void email_null_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = createSignInDto(null, "1234");
+
+    // when
+    ConstraintViolation<SignInDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("이메일을 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void email_nullString_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = createSignInDto("", "1234");
+
+    // when
+    ConstraintViolation<SignInDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("이메일을 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void email_형식_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = createSignInDto("asdf", "1234");
+
+    // when
+    ConstraintViolation<SignInDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("이메일 형식으로 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void password_null_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = createSignInDto("test@email.com", null);
+
+    // when
+    ConstraintViolation<SignInDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("비밀번호를 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void password_nullString_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = createSignInDto("test@email.com", "");
+
+    // when
+    ConstraintViolation<SignInDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("비밀번호를 입력해주세요.", result.getMessage());
+  }
+}

--- a/src/test/java/com/numble/team3/sign/application/request/SignUpDtoTest.java
+++ b/src/test/java/com/numble/team3/sign/application/request/SignUpDtoTest.java
@@ -1,0 +1,125 @@
+package com.numble.team3.sign.application.request;
+
+import static com.numble.team3.factory.dto.SignDtoFactory.createSignUpDto;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("SignUpDto Valid 테스트")
+class SignUpDtoTest {
+
+  Validator validator;
+
+  @BeforeEach
+  void beforeEach() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  void 검증_성공_테스트() throws Exception {
+    // given
+    SignUpDto dto = createSignUpDto("test@email.com", "1234", "nickname");
+
+    // when
+    Set<ConstraintViolation<SignUpDto>> validate = validator.validate(dto);
+
+    // then
+    assertTrue(validate.isEmpty());
+  }
+
+  @Test
+  void email_null_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = createSignUpDto(null, "1234", "nickname");
+
+    // when
+    ConstraintViolation<SignUpDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("이메일을 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void email_nullString_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = createSignUpDto("", "1234", "nickname");
+
+    // when
+    ConstraintViolation<SignUpDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("이메일을 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void email_형식_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = createSignUpDto("asdf", "1234", "nickname");
+
+    // when
+    ConstraintViolation<SignUpDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("이메일 형식으로 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void password_null_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = createSignUpDto("test@email.com", null, "nickname");
+
+    // when
+    ConstraintViolation<SignUpDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("비밀번호를 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void password_nullString_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = createSignUpDto("test@email.com", "", "nickname");
+
+    // when
+    ConstraintViolation<SignUpDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("비밀번호를 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void nickname_null_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = createSignUpDto("test@email.com", "1234", null);
+
+    // when
+    ConstraintViolation<SignUpDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("닉네임을 입력해주세요.", result.getMessage());
+  }
+
+  @Test
+  void nickname_nullString_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = createSignUpDto("test@email.com", "1234", "");
+
+    // when
+    ConstraintViolation<SignUpDto> result = validator.validate(dto).iterator().next();
+
+    // then
+    assertEquals("닉네임을 입력해주세요.", result.getMessage());
+  }
+}

--- a/src/test/java/com/numble/team3/sign/controller/SignControllerAdviceTest.java
+++ b/src/test/java/com/numble/team3/sign/controller/SignControllerAdviceTest.java
@@ -1,0 +1,329 @@
+package com.numble.team3.sign.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numble.team3.exception.account.AccountNotFoundException;
+import com.numble.team3.exception.account.AccountWithdrawalException;
+import com.numble.team3.exception.sign.SignInFailureException;
+import com.numble.team3.exception.sign.TokenFailureException;
+import com.numble.team3.factory.dto.SignDtoFactory;
+import com.numble.team3.sign.application.SignService;
+import com.numble.team3.sign.application.advice.SignRestControllerAdvice;
+import com.numble.team3.sign.application.request.SignInDto;
+import com.numble.team3.sign.application.request.SignUpDto;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("SignRestControllerAdvice 테스트")
+public class SignControllerAdviceTest {
+
+  @Mock
+  SignService signService;
+
+  @InjectMocks
+  SignController signController;
+
+  ObjectMapper objectMapper = new ObjectMapper();
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void beforeEach() {
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(signController)
+      .setControllerAdvice(new SignRestControllerAdvice())
+      .addFilter(new CharacterEncodingFilter("UTF-8", true))
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void signUp_email_누락_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = SignDtoFactory.createSignUpDto(null, "1234", "nickname");
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-up")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto)));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("이메일을 입력해주세요."));
+  }
+
+  @Test
+  void signUp_email_형식_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = SignDtoFactory.createSignUpDto("이메일 형식 아님", "1234", "nickname");
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-up")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto)));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("이메일 형식으로 입력해주세요."));
+  }
+
+  @Test
+  void signUp_nickname_누락_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = SignDtoFactory.createSignUpDto("test@email.com", "1234", null);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-up")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto)));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("닉네임을 입력해주세요."));
+  }
+
+  @Test
+  void signUp_password_누락_실패_테스트() throws Exception {
+    // given
+    SignUpDto dto = SignDtoFactory.createSignUpDto("test@email.com", null, "닉네임");
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-up")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto)));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("비밀번호를 입력해주세요."));
+  }
+
+  @Test
+  void signIn_email_누락_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = SignDtoFactory.createSignInDto(null, "1234");
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-in")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto)));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("이메일을 입력해주세요."));
+  }
+
+  @Test
+  void signIn_password_누락_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = SignDtoFactory.createSignInDto("test@email.com", null);
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-in")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto)));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("비밀번호를 입력해주세요."));
+  }
+
+  @Test
+  void signIn_없는_계정_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = SignDtoFactory.createSignInDto("test@email.com", "1234");
+
+    given(signService.signIn(any(SignInDto.class))).willThrow(new SignInFailureException());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-in")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto)));
+
+    // then
+    result
+      .andExpect(status().isUnauthorized())
+      .andExpect(jsonPath("$.message").value("로그인에 실패했습니다."));
+  }
+
+  @Test
+  void signIn_탈퇴한_계정_실패_테스트() throws Exception {
+    // given
+    SignInDto dto = SignDtoFactory.createSignInDto("test@email.com", "1234");
+
+    given(signService.signIn(any(SignInDto.class))).willThrow(new AccountWithdrawalException());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-in")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto)));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("이미 탈퇴처리 된 계정입니다."));
+  }
+
+  @Test
+  void logout_헤더_토큰_누락_실패_테스트() throws Exception {
+    // given
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/logout"));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("Authorization 헤더가 누락되었습니다."));
+  }
+
+  @Test
+  void logout_토큰_만료_실패_이벤트() throws Exception {
+    // given
+    willThrow(new TokenFailureException()).given(signService).logout(anyString());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/logout").header("Authorization", "Bearer accessToken"));
+
+    // then
+    result
+      .andExpect(status().isUnauthorized())
+      .andExpect(jsonPath("$.message").value("유효하지 않은 토큰입니다."));
+  }
+
+  @Test
+  void createAccessTokenByRefreshToken_쿠키_누락_실패_테스트() throws Exception {
+    // given
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/refresh-token"));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("refreshToken 쿠키가 누락되었습니다."));
+  }
+
+  @Test
+  void createAccessTokenByRefreshToken_쿠키_이름_실패_테스트() throws Exception {
+    // given
+    Cookie mockCookie = Mockito.mock(Cookie.class);
+    given(mockCookie.getName()).willReturn("refreshToken 쿠키 아님");
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/refresh-token").cookie(mockCookie));
+
+    // then
+    result
+      .andExpect(status().isUnauthorized())
+      .andExpect(jsonPath("$.message").value("refreshToken 쿠키가 누락되었습니다."));
+  }
+
+  @Test
+  void createAccessTokenByRefreshToken_토큰_만료_실패_테스트() throws Exception {
+    // given
+    Cookie mockCookie = Mockito.mock(Cookie.class);
+    given(mockCookie.getName()).willReturn("refreshToken");
+    given(mockCookie.getValue()).willReturn(URLEncoder.encode("refreshToken", StandardCharsets.UTF_8));
+    given(signService.createAccessTokenByRefreshToken(anyString())).willThrow(new TokenFailureException());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/refresh-token").cookie(mockCookie));
+
+    // then
+    result
+      .andExpect(status().isUnauthorized())
+      .andExpect(jsonPath("$.message").value("유효하지 않은 토큰입니다."));
+  }
+
+  @Test
+  void accountWithdrawal_헤더_토큰_누락_실패_테스트() throws Exception {
+    // given
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/withdrawal"));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("Authorization 헤더가 누락되었습니다."));
+  }
+
+  @Test
+  void accountWithdrawal_토큰_만료_실패_테스트() throws Exception {
+    // given
+    willThrow(new TokenFailureException()).given(signService).withdrawal(anyString());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/withdrawal")
+        .header("Authorization", "Bearer accessToken"));
+
+    // then
+    result
+      .andExpect(status().isUnauthorized())
+      .andExpect(jsonPath("$.message").value("유효하지 않은 토큰입니다."));
+  }
+
+  @Test
+  void accountWithdrawal_없는_계정_실패_테스트() throws Exception {
+    // given
+    willThrow(new AccountNotFoundException()).given(signService).withdrawal(anyString());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/withdrawal").header("Authorization", "Bearer accessToken"));
+
+    // then
+    result
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.message").value("존재하지 않는 이메일입니다."));
+  }
+}
+

--- a/src/test/java/com/numble/team3/sign/controller/SignControllerTest.java
+++ b/src/test/java/com/numble/team3/sign/controller/SignControllerTest.java
@@ -1,0 +1,156 @@
+package com.numble.team3.sign.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numble.team3.factory.dto.SignDtoFactory;
+import com.numble.team3.sign.application.SignService;
+import com.numble.team3.sign.application.request.SignInDto;
+import com.numble.team3.sign.application.request.SignUpDto;
+import com.numble.team3.sign.application.response.TokenDto;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("SignController 테스트")
+class SignControllerTest {
+
+  @Mock
+  SignService signService;
+
+  @InjectMocks
+  SignController signController;
+
+  MockMvc mockMvc;
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void beforeEach() {
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(signController)
+      .alwaysDo(print())
+      .build();
+  }
+
+  @Test
+  void signUp_테스트() throws Exception {
+    // given
+    SignUpDto dto = SignDtoFactory.createSignUpDto("test@email.com", "1234", "닉네임");
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-up")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto))
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result.andExpect(status().isCreated());
+  }
+
+  @Test
+  void signIn_테스트() throws Exception {
+    // given
+    SignInDto dto = SignDtoFactory.createSignInDto("test@email.com", "1234");
+
+    given(signService.signIn(any(SignInDto.class)))
+      .willReturn(new TokenDto("accessToken", "refreshToken"));
+
+    // when
+    ResultActions result = mockMvc.perform(
+      post("/api/sign-in")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(dto))
+        .accept(MediaType.APPLICATION_JSON_VALUE));
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.accessToken").value("accessToken"))
+      .andExpect(jsonPath("$.refreshToken").value("refreshToken"))
+      .andExpect(cookie().value("refreshToken", "refreshToken"))
+      .andExpect(cookie().maxAge("refreshToken", 604800))
+      .andExpect(cookie().path("refreshToken", "/"))
+      .andExpect(cookie().secure("refreshToken", true))
+      .andExpect(cookie().httpOnly("refreshToken", true));
+  }
+
+  @Test
+  void logout_테스트() throws Exception {
+    // given
+    willDoNothing().given(signService).logout(anyString());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      get("/api/logout")
+        .header("Authorization", "Bearer accessToken"));
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(cookie().path("refreshToken", "/"))
+      .andExpect(cookie().maxAge("refreshToken", 0));
+  }
+
+  @Test
+  void createAccessTokenByRefreshToken_테스트() throws Exception {
+    // given
+    Cookie mockCookie = Mockito.mock(Cookie.class);
+    TokenDto token = new TokenDto("new-accessToken", "refreshToken");
+    given(mockCookie.getName()).willReturn("refreshToken");
+    given(mockCookie.getValue()).willReturn(URLEncoder.encode("refreshToken", StandardCharsets.UTF_8));
+    given(signService.createAccessTokenByRefreshToken(anyString())).willReturn(token);
+
+    // when
+    ResultActions result = mockMvc.perform(get("/api/refresh-token").cookie(mockCookie));
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.accessToken").value("new-accessToken"))
+      .andExpect(jsonPath("$.refreshToken").value("refreshToken"));
+  }
+
+  @Test
+  void accountWithdrawal_테스트() throws Exception {
+    // given
+    willDoNothing().given(signService).withdrawal(anyString());
+
+    // when
+    ResultActions result = mockMvc.perform(
+      delete("/api/withdrawal")
+        .header("Authorization", "Bearer accessToken"));
+
+    // then
+    result
+      .andExpect(status().isOk())
+      .andExpect(cookie().path("refreshToken", "/"))
+      .andExpect(cookie().maxAge("refreshToken", 0));
+  }
+}


### PR DESCRIPTION
## 개요
- #71 

## 작업사항
- 다음 기능에 대한 테스트 코드를 추가했습니다.
    - `account`
    - `admin` (회원관리)
    - `convert` (이미지)
    - `like`
    - `jwt` 
    - `sign`
- 테스트 코드 작성 시 필요한 `DTO`나 `Entity` 생성은 `factory` 패키지 안에 따로 `static 메소드`로 생성했습니다.