### PR TITLE
[feat] #61 비디오 조회수 증가 기능 구현

### DIFF
--- a/src/main/java/com/numble/team3/video/application/VideoService.java
+++ b/src/main/java/com/numble/team3/video/application/VideoService.java
@@ -10,6 +10,7 @@ import com.numble.team3.video.application.response.GetVideoDetailDto;
 import com.numble.team3.video.application.response.GetVideoListDto;
 import com.numble.team3.video.domain.Video;
 import com.numble.team3.video.infra.JpaVideoRepository;
+import com.numble.team3.video.infra.VideoRedisUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class VideoService {
   private final JpaAccountRepository accountRepository;
   private final JpaVideoRepository videoRepository;
+  private final VideoRedisUtils videoRedisUtils;
 
   private Account findByAccountId(Long accountId) {
     return accountRepository.findById(accountId).orElseThrow(AccountNotFoundException::new);
@@ -74,6 +76,8 @@ public class VideoService {
 
   @Transactional(readOnly = true)
   public GetVideoDetailDto getVideoById(Long videoId) {
+    Long viewCount = videoRedisUtils.getViewCountByVideoId(videoId);
+    videoRedisUtils.countView(viewCount + 1, videoId);
     return GetVideoDetailDto.fromEntity(
         videoRepository.findById(videoId).orElseThrow(VideoNotFoundException::new));
   }

--- a/src/main/java/com/numble/team3/video/controller/VideoController.java
+++ b/src/main/java/com/numble/team3/video/controller/VideoController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,10 +28,9 @@ public class VideoController {
 
   private final VideoService videoService;
 
-  @PostMapping(value = "/video")
+  @PostMapping(value = "/videos")
   public ResponseEntity createVideo(
-      @LoginUser UserInfo userInfo,
-      @Valid @RequestPart(value = "dto") CreateOrUpdateVideoDto dto) {
+      @LoginUser UserInfo userInfo, @Valid @RequestBody CreateOrUpdateVideoDto dto) {
     videoService.createVideo(userInfo, dto);
     return new ResponseEntity<>(HttpStatus.CREATED);
   }

--- a/src/main/java/com/numble/team3/video/domain/VideoUtils.java
+++ b/src/main/java/com/numble/team3/video/domain/VideoUtils.java
@@ -1,0 +1,7 @@
+package com.numble.team3.video.domain;
+
+public interface VideoUtils {
+  Long getViewCountByVideoId(Long VideoId);
+
+  void countView(Long curViewCount, Long videoId);
+}

--- a/src/main/java/com/numble/team3/video/domain/VideoUtils.java
+++ b/src/main/java/com/numble/team3/video/domain/VideoUtils.java
@@ -1,7 +1,9 @@
 package com.numble.team3.video.domain;
 
-public interface VideoUtils {
-  Long getViewCountByVideoId(Long VideoId);
+import java.util.Map;
 
-  void countView(Long curViewCount, Long videoId);
+public interface VideoUtils {
+  void updateViewCount(Long videoId);
+
+  Map<Long, Long> getAllVideoViewCount();
 }

--- a/src/main/java/com/numble/team3/video/infra/JpaVideoRepository.java
+++ b/src/main/java/com/numble/team3/video/infra/JpaVideoRepository.java
@@ -5,7 +5,9 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,4 +16,8 @@ public interface JpaVideoRepository extends JpaRepository<Video, Long> {
 
   @Query("SELECT v FROM Video v JOIN FETCH v.account WHERE v.deleteYn = false")
   List<Video> findAllWithAccount(Pageable pageable);
+
+  @Modifying
+  @Query("UPDATE Video v SET v.view = v.view + :viewCount WHERE v.id = :videoId")
+  void updateVideoViewCount(@Param("viewCount") Long viewCount, @Param("videoId") Long videoId);
 }

--- a/src/main/java/com/numble/team3/video/infra/VideoRedisUtils.java
+++ b/src/main/java/com/numble/team3/video/infra/VideoRedisUtils.java
@@ -1,0 +1,28 @@
+package com.numble.team3.video.infra;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numble.team3.video.domain.VideoUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VideoRedisUtils implements VideoUtils {
+  private final RedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+  private final String PREFIX_VIDEO_VIEW = "VIDEO::VIEW::";
+
+  @Override
+  public Long getViewCountByVideoId(Long videoId) {
+    if(!redisTemplate.hasKey(PREFIX_VIDEO_VIEW + String.valueOf(videoId))){
+      return 0L;
+    }
+    return Long.valueOf((String) redisTemplate.opsForValue().get(PREFIX_VIDEO_VIEW + String.valueOf(videoId)));
+  }
+
+  @Override
+  public void countView(Long curViewCount, Long videoId) {
+    redisTemplate.opsForValue().set(PREFIX_VIDEO_VIEW + String.valueOf(videoId), String.valueOf(curViewCount));
+  }
+}

--- a/src/main/java/com/numble/team3/video/scheduler/VideoViewScheduler.java
+++ b/src/main/java/com/numble/team3/video/scheduler/VideoViewScheduler.java
@@ -1,0 +1,21 @@
+package com.numble.team3.video.scheduler;
+
+import com.numble.team3.video.application.VideoService;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class VideoViewScheduler {
+  private final VideoService videoService;
+
+  @Scheduled(cron = "0 0 2 * * *")
+  public void updateVideoViewCount(){
+    log.info("{}: [update view count]", LocalDateTime.now());
+    videoService.updateViewCountWithRedis();
+  }
+}


### PR DESCRIPTION
## 개요
#61 
## 작업사항
- 비디오 상세조회마다 레디스에 조회수를 카운트합니다.
- 매일 2시마다 레디스에 저장된 조회수를 DB에 업데이트합니다.