### PR TITLE
[Feat] #78 댓글 좋아요 카운트 생성, 삭제, 조회 구현

### DIFF
--- a/src/main/java/com/numble/team3/comment/application/response/GetCommentDto.java
+++ b/src/main/java/com/numble/team3/comment/application/response/GetCommentDto.java
@@ -16,6 +16,7 @@ public class GetCommentDto {
   private String nickname;
   private String profilePath;
   private String content;
+  private boolean isLiked = false;
   private long like;
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh-MM-ss", timezone = "Asia/Seoul")

--- a/src/main/java/com/numble/team3/comment/application/response/GetCommentDto.java
+++ b/src/main/java/com/numble/team3/comment/application/response/GetCommentDto.java
@@ -16,10 +16,12 @@ public class GetCommentDto {
   private String nickname;
   private String profilePath;
   private String content;
-  private boolean isLiked = false;
   private long like;
 
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh-MM-ss", timezone = "Asia/Seoul")
+  @JsonFormat(
+      shape = JsonFormat.Shape.STRING,
+      pattern = "yyyy-MM-dd hh-MM-ss",
+      timezone = "Asia/Seoul")
   @JsonSerialize(using = LocalDateTimeSerializer.class)
   private LocalDateTime createdAt;
 

--- a/src/main/java/com/numble/team3/comment/application/response/GetCommentListDto.java
+++ b/src/main/java/com/numble/team3/comment/application/response/GetCommentListDto.java
@@ -12,17 +12,28 @@ import org.springframework.data.domain.Slice;
 @NoArgsConstructor
 public class GetCommentListDto {
   private List<GetCommentDto> contents;
+  private List<Long> likeComments;
   private boolean hasNext;
 
   @Builder
-  private GetCommentListDto(List<GetCommentDto> contents, boolean hasNext) {
+  private GetCommentListDto(
+      List<GetCommentDto> contents, List<Long> likeComments, boolean hasNext) {
     this.contents = contents;
+    this.likeComments = likeComments;
     this.hasNext = hasNext;
   }
 
   public static GetCommentListDto fromEntities(Slice<Comment> comments) {
     return GetCommentListDto.builder()
+      .contents(comments.stream().map(GetCommentDto::fromEntity).collect(Collectors.toList()))
+      .hasNext(comments.hasNext())
+      .build();
+  }
+
+  public static GetCommentListDto fromEntities(Slice<Comment> comments, List<Long> likeComments) {
+    return GetCommentListDto.builder()
         .contents(comments.stream().map(GetCommentDto::fromEntity).collect(Collectors.toList()))
+        .likeComments(likeComments)
         .hasNext(comments.hasNext())
         .build();
   }

--- a/src/main/java/com/numble/team3/comment/controller/CommentController.java
+++ b/src/main/java/com/numble/team3/comment/controller/CommentController.java
@@ -55,12 +55,14 @@ public class CommentController {
 
   @GetMapping("/videos/{videoId}/comments")
   public ResponseEntity<GetCommentListDto> getAllCommentByVideoId(
+      @LoginUser UserInfo userInfo,
       @PathVariable Long videoId,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "5") int size,
-      @RequestParam(name = "sort", defaultValue = CommentSortCondition.DEFAULT) CommentSortCondition commentSortCondition) {
+      @RequestParam(name = "sort", defaultValue = CommentSortCondition.DEFAULT)
+          CommentSortCondition commentSortCondition) {
     return ResponseEntity.ok(
         commentService.getAllCommentByVideoIdWithCondition(
-            videoId, commentSortCondition, PageRequest.of(page, size)));
+            userInfo, videoId, commentSortCondition, PageRequest.of(page, size)));
   }
 }

--- a/src/main/java/com/numble/team3/comment/controller/CommentLikeController.java
+++ b/src/main/java/com/numble/team3/comment/controller/CommentLikeController.java
@@ -1,0 +1,34 @@
+package com.numble.team3.comment.controller;
+
+import com.numble.team3.account.annotation.LoginUser;
+import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.comment.application.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CommentLikeController {
+  private final CommentService commentService;
+
+  @PostMapping("/videos/{videoId}/comments/{commentId}/likes")
+  public ResponseEntity createCommentLikeById(
+      @LoginUser UserInfo userInfo, @PathVariable Long videoId, @PathVariable Long commentId) {
+    commentService.createCommentLikeById(userInfo, videoId, commentId);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  @DeleteMapping("/videos/{videoId}/comments/{commentId}/likes")
+  public ResponseEntity deleteCommentLikeById(
+      @LoginUser UserInfo userInfo, @PathVariable Long videoId, @PathVariable Long commentId) {
+    commentService.deleteCommentLikeById(userInfo, videoId, commentId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+}

--- a/src/main/java/com/numble/team3/comment/domain/AccountLikeComment.java
+++ b/src/main/java/com/numble/team3/comment/domain/AccountLikeComment.java
@@ -1,0 +1,38 @@
+package com.numble.team3.comment.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tb_account_like_comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AccountLikeComment {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "account_like_comment_id")
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "comment_id")
+  private Comment likedComment;
+
+  private Long videoId;
+
+  private Long accountId;
+
+  public AccountLikeComment(Comment comment, Long videoId, Long accountId) {
+    this.likedComment = comment;
+    this.videoId = videoId;
+    this.accountId = accountId;
+  }
+}

--- a/src/main/java/com/numble/team3/comment/domain/Comment.java
+++ b/src/main/java/com/numble/team3/comment/domain/Comment.java
@@ -3,22 +3,23 @@ package com.numble.team3.comment.domain;
 import com.numble.team3.account.domain.Account;
 import com.numble.team3.common.entity.BaseTimeEntity;
 import com.numble.team3.video.domain.Video;
-import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Entity
@@ -40,11 +41,43 @@ public class Comment extends BaseTimeEntity {
   private Long like;
 
   @ManyToOne private Account account;
+
   @ManyToOne private Video video;
+
+  @OneToMany(
+      mappedBy = "likedComment",
+      fetch = FetchType.LAZY,
+      cascade = CascadeType.ALL,
+      orphanRemoval = true)
+  private List<AccountLikeComment> accountLikeCommentList = new ArrayList<>();
 
   // 도메인 행위 메서드
   public void commentDelete() {
     this.deleteYn = true;
+  }
+
+  public void deleteCommentLike(Long accountId, Long commentId) {
+    if (!accountLikeCommentList.stream()
+        .filter(entity -> entity.getAccountId() == accountId)
+        .findAny()
+        .isPresent()) {
+      return;
+    }
+    this.like -= 1L;
+    this.accountLikeCommentList.removeIf(
+        entity ->
+            (entity.getLikedComment().getId() == commentId && entity.getAccountId() == accountId));
+  }
+
+  public void addCommentLike(Comment comment, Long videoId, Long accountId) {
+    if (accountLikeCommentList.stream()
+        .filter(entity -> entity.getAccountId() == accountId)
+        .findAny()
+        .isPresent()) {
+      return;
+    }
+    this.like += 1L;
+    this.accountLikeCommentList.add(new AccountLikeComment(comment, videoId, accountId));
   }
 
   private Comment(String content, Video video, Account account) {

--- a/src/main/java/com/numble/team3/comment/infra/JpaCommentLikeRepository.java
+++ b/src/main/java/com/numble/team3/comment/infra/JpaCommentLikeRepository.java
@@ -1,0 +1,16 @@
+package com.numble.team3.comment.infra;
+
+import com.numble.team3.comment.domain.AccountLikeComment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface JpaCommentLikeRepository extends JpaRepository<AccountLikeComment, Long> {
+  @Query(
+      "SELECT a FROM AccountLikeComment a WHERE a.videoId = :videoId AND a.accountId = :accountId AND a.likedComment.id IN :commentIds")
+  List<AccountLikeComment> findAllByAccountIdAndVideoId(
+      @Param("accountId") Long accountId,
+      @Param("videoId") Long videoId,
+      @Param("commentIds") List<Long> commentIds);
+}

--- a/src/main/java/com/numble/team3/comment/infra/JpaCommentRepository.java
+++ b/src/main/java/com/numble/team3/comment/infra/JpaCommentRepository.java
@@ -13,4 +13,10 @@ public interface JpaCommentRepository
   @Query("SELECT c FROM Comment c WHERE c.account.id = :accountId and c.id = :commentId")
   Optional<Comment> findCommentByAccountIdWithId(
       @Param("accountId") Long accountId, @Param("commentId") Long commentId);
+
+  @Query(
+      "SELECT c FROM Comment c LEFT JOIN FETCH c.accountLikeCommentList"
+        + " JOIN FETCH c.account JOIN FETCH c.video WHERE c.id = :commentId AND c.account.id = :accountId")
+  Optional<Comment> findCommentFetchJoinByIdAndAccountId(
+      @Param("commentId") Long commentId, @Param("accountId") Long accountId);
 }


### PR DESCRIPTION
<!-- 
    PR 제목은 다음과 같은 형식으로 작성합니다.

    gitmoji [Feature/domain-issue number] title
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
    
    PR에 사용되는 Gitmoji 가이드입니다.
    
    feat(✨) - Introduce new features
    fix(🐛) - Fix a bug
    docs(📝) - Add or update documentation
    style(🎨) - Improve structure / format of the code
    refactor(♻️) - Refactor code
    perf(⚡️) - Improve performance
    test(✅) - Add or update tests
    build(👷) - Add or update CI build system
    ci(💚) - Fix CI Build
    chore(⚙️) - Other changes 
    revert(⏪️) - Revert changes
    hotfix(🚑️) - Critical hotfix
-->

### 💡 개요
<!-- 해당 pr이 등록된 배경, 개요를 간단하게 작성해보세요 -->

<!-- #뒤에는 이슈 번호를 걸어주세요~ -->
- resolved #0

### 📑 작업 사항
<!-- 진행한 작업에 관한 내용을 작성해주세요. (스크린 샷이 있다면 첨부해주세요) -->
1. 댓글에 좋아요를 누른 유저들을 관리하기 위해 엔티티를 만들었습니다.
  1.1. 해당 엔티티는 댓글에 종속적이라 생각하여 댓글 도메인에 포함시켰습니다.
  1.2. 댓글 엔티티를 통해 생성, 삭제를 구현했습니다.
2. 댓글 조회 시 댓글 엔티티 + 댓글 좋아요 엔티티를 조회하기 위한 쿼리를 날리도록 했습니다.
  2.1 조회 속도를 빠르게 하기 위해 댓글 엔티티 내부에 좋아요 개수를 카운트하도록 했습니다.

### ✒️ 코드 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐야 하는 포인트나 궁금한 점을 작성해주세요. -->
1. 댓글 도메인에 종속적인 개념이 맞을까용?


### ✔️ 코드 리뷰 반영 사항
<!-- 코드 리뷰에 대한 반영사항을 작성해주세요. (재 PR 시에만 작성합니다) -->
