### PR TITLE
[refactor] Cookie 생성 방식 변경

### DIFF
--- a/src/main/java/com/numble/team3/sign/controller/SignController.java
+++ b/src/main/java/com/numble/team3/sign/controller/SignController.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -95,20 +96,28 @@ public class SignController {
   }
 
   private void createCookie(String token, int maxAge, HttpServletResponse response) {
-    Cookie cookie = new Cookie("refreshToken", URLEncoder.encode(token, StandardCharsets.UTF_8));
-    cookie.setSecure(true);
-    cookie.setHttpOnly(true);
-    cookie.setMaxAge(maxAge);
-    cookie.setPath("/");
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", URLEncoder.encode(token, StandardCharsets.UTF_8))
+      .secure(true)
+      .httpOnly(true)
+      .path("/")
+      .maxAge(maxAge)
+      .sameSite("None")
+      .domain("localhost")
+      .build();
 
-    response.addCookie(cookie);
+    response.addHeader("Set-Cookie", cookie.toString());
   }
 
   private void deleteCookie(HttpServletResponse response) {
-    Cookie cookie = new Cookie("refreshToken", null);
-    cookie.setMaxAge(0);
-    cookie.setPath("/");
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", null)
+      .secure(true)
+      .httpOnly(true)
+      .path("/")
+      .maxAge(0)
+      .sameSite("None")
+      .domain("localhost")
+      .build();
 
-    response.addCookie(cookie);
+    response.addHeader("Set-Cookie", cookie.toString());
   }
 }


### PR DESCRIPTION
<!-- 
    PR 제목은 다음과 같은 형식으로 작성합니다.

    gitmoji [Feature/domain-issue number] title
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
    
    PR에 사용되는 Gitmoji 가이드입니다.
    
    feat(✨) - Introduce new features
    fix(🐛) - Fix a bug
    docs(📝) - Add or update documentation
    style(🎨) - Improve structure / format of the code
    refactor(♻️) - Refactor code
    perf(⚡️) - Improve performance
    test(✅) - Add or update tests
    build(👷) - Add or update CI build system
    ci(💚) - Fix CI Build
    chore(⚙️) - Other changes 
    revert(⏪️) - Revert changes
    hotfix(🚑️) - Critical hotfix
-->

### 💡 개요
<!-- 해당 pr이 등록된 배경, 개요를 간단하게 작성해보세요 -->
- `Cookie` 생성 방식 변경

### 📑 작업 사항
<!-- 진행한 작업에 관한 내용을 작성해주세요. (스크린 샷이 있다면 첨부해주세요) -->
- 크롬(Google Chrome)80 Cookie 이슈로 인해 프론트엔드에서 쿠키가 저장되지 않는 현상이 발생했습니다.
  - `SignController`에서 로그인 했을때와 로그아웃 했을 때의 쿠키를 `ResponseCookie`를 통해 생성하는 것으로 로직을 변경했습니다.
  - 현재는 프론트엔드가 배포되지 않은 상태이기 때문에 `domain`을 `localhost`로 설정했습니다.