### PR TITLE
[refactor] #120 Sign 쿠키 관련 로직 삭제

### DIFF
--- a/src/main/java/com/numble/team3/sign/annotation/CreateAccessTokenSwagger.java
+++ b/src/main/java/com/numble/team3/sign/annotation/CreateAccessTokenSwagger.java
@@ -34,17 +34,6 @@ import java.lang.annotation.Target;
     )
   }
 )
-@ApiImplicitParams(
-  value = {
-    @ApiImplicitParam(
-      name = "Cookie",
-      value = "refresh token 쿠키",
-      required = true,
-      dataTypeClass = String.class,
-      paramType = "body"
-    ),
-  }
-)
 public @interface CreateAccessTokenSwagger {
 
 }

--- a/src/test/java/com/numble/team3/sign/controller/SignControllerAdviceTest.java
+++ b/src/test/java/com/numble/team3/sign/controller/SignControllerAdviceTest.java
@@ -234,7 +234,7 @@ public class SignControllerAdviceTest {
   }
 
   @Test
-  void createAccessTokenByRefreshToken_쿠키_누락_실패_테스트() throws Exception {
+  void createAccessTokenByRefreshToken_헤더_토큰_누락_실패_테스트() throws Exception {
     // given
 
     // when
@@ -244,36 +244,17 @@ public class SignControllerAdviceTest {
     // then
     result
       .andExpect(status().isBadRequest())
-      .andExpect(jsonPath("$.message").value("refreshToken 쿠키가 누락되었습니다."));
+      .andExpect(jsonPath("$.message").value("Authorization 헤더가 누락되었습니다."));
   }
 
   @Test
-  void createAccessTokenByRefreshToken_쿠키_이름_실패_테스트() throws Exception {
+  void createAccessTokenByRefreshToken_토큰_만료_실패_이벤트() throws Exception {
     // given
-    Cookie mockCookie = Mockito.mock(Cookie.class);
-    given(mockCookie.getName()).willReturn("refreshToken 쿠키 아님");
-
-    // when
-    ResultActions result = mockMvc.perform(
-      get("/api/refresh-token").cookie(mockCookie));
-
-    // then
-    result
-      .andExpect(status().isUnauthorized())
-      .andExpect(jsonPath("$.message").value("refreshToken 쿠키가 누락되었습니다."));
-  }
-
-  @Test
-  void createAccessTokenByRefreshToken_토큰_만료_실패_테스트() throws Exception {
-    // given
-    Cookie mockCookie = Mockito.mock(Cookie.class);
-    given(mockCookie.getName()).willReturn("refreshToken");
-    given(mockCookie.getValue()).willReturn(URLEncoder.encode("refreshToken", StandardCharsets.UTF_8));
     given(signService.createAccessTokenByRefreshToken(anyString())).willThrow(new TokenFailureException());
 
     // when
     ResultActions result = mockMvc.perform(
-      get("/api/refresh-token").cookie(mockCookie));
+      get("/api/refresh-token").header("Authorization", "Bearer accessToken"));
 
     // then
     result

--- a/src/test/java/com/numble/team3/sign/controller/SignControllerTest.java
+++ b/src/test/java/com/numble/team3/sign/controller/SignControllerTest.java
@@ -93,11 +93,7 @@ class SignControllerTest {
     result
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.accessToken").value("accessToken"))
-      .andExpect(jsonPath("$.refreshToken").value("refreshToken"))
-      .andExpect(cookie().value("refreshToken", "refreshToken"))
-      .andExpect(cookie().maxAge("refreshToken", 604800))
-      .andExpect(cookie().path("refreshToken", "/"))
-      .andExpect(cookie().httpOnly("refreshToken", true));
+      .andExpect(jsonPath("$.refreshToken").value("refreshToken"));
   }
 
   @Test
@@ -112,22 +108,19 @@ class SignControllerTest {
 
     // then
     result
-      .andExpect(status().isOk())
-      .andExpect(cookie().path("refreshToken", "/"))
-      .andExpect(cookie().maxAge("refreshToken", 0));
+      .andExpect(status().isOk());
   }
 
   @Test
   void createAccessTokenByRefreshToken_테스트() throws Exception {
     // given
-    Cookie mockCookie = Mockito.mock(Cookie.class);
     TokenDto token = new TokenDto("new-accessToken", "refreshToken");
-    given(mockCookie.getName()).willReturn("refreshToken");
-    given(mockCookie.getValue()).willReturn(URLEncoder.encode("refreshToken", StandardCharsets.UTF_8));
     given(signService.createAccessTokenByRefreshToken(anyString())).willReturn(token);
 
     // when
-    ResultActions result = mockMvc.perform(get("/api/refresh-token").cookie(mockCookie));
+    ResultActions result = mockMvc.perform(
+      get("/api/refresh-token")
+        .header("Authorization", "Bearer refresh token"));
 
     // then
     result
@@ -148,8 +141,6 @@ class SignControllerTest {
 
     // then
     result
-      .andExpect(status().isOk())
-      .andExpect(cookie().path("refreshToken", "/"))
-      .andExpect(cookie().maxAge("refreshToken", 0));
+      .andExpect(status().isOk());
   }
 }


### PR DESCRIPTION
<!-- 
    PR 제목은 다음과 같은 형식으로 작성합니다.

    gitmoji [Feature/domain-issue number] title
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
    
    PR에 사용되는 Gitmoji 가이드입니다.
    
    feat(✨) - Introduce new features
    fix(🐛) - Fix a bug
    docs(📝) - Add or update documentation
    style(🎨) - Improve structure / format of the code
    refactor(♻️) - Refactor code
    perf(⚡️) - Improve performance
    test(✅) - Add or update tests
    build(👷) - Add or update CI build system
    ci(💚) - Fix CI Build
    chore(⚙️) - Other changes 
    revert(⏪️) - Revert changes
    hotfix(🚑️) - Critical hotfix
-->

### 💡 개요
- resolved #120 

### 📑 작업 사항
- `SignController`에서 쿠키와 관련된 로직을 모두 제거했습니다.
- `/api/refresh-token`에서 쿠키로 토큰을 받는 로직을 `Authorization`을 통해 쿠키를 받도록 변경했습니다.
- 관련 `Swagger`, 테스트 코드를 수정했습니다.