### PR TITLE
[rename] Response Dto Field 이름 변경

### DIFF
--- a/src/main/java/com/numble/team3/admin/annotation/GetAccountVideosSwagger.java
+++ b/src/main/java/com/numble/team3/admin/annotation/GetAccountVideosSwagger.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
     @ApiResponse(
       code = 200,
       message = "비디오 조회 성공",
-      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{ \n\"videos\" : [ \n\t { \n\t\t \"videoId\" : 영상 ID, \n\t\t \"thumbnailPath\" : \"썸네일 경로\", \n\t\t \"title\" : \"영상 제목\" \n\t } \n\t ], \n\t \"totalCount\" : 전체 업로드 수, \n\t \"nowPage\" : 현재 페이지, \n\t \"totalPage\" : 전체 페이지 , \n\t \"size\" : 페이지 크기 \n}"))
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{ \n\"videos\" : [ \n\t { \n\t\t \"videoId\" : 영상 ID, \n\t\t \"thumbnailUrl\" : \"썸네일 경로\", \n\t\t \"title\" : \"영상 제목\" \n\t } \n\t ], \n\t \"totalCount\" : 전체 업로드 수, \n\t \"nowPage\" : 현재 페이지, \n\t \"totalPage\" : 전체 페이지 , \n\t \"size\" : 페이지 크기 \n}"))
     ),
     @ApiResponse(
       code = 401,

--- a/src/main/java/com/numble/team3/admin/application/response/GetSimpleAccountVideoDto.java
+++ b/src/main/java/com/numble/team3/admin/application/response/GetSimpleAccountVideoDto.java
@@ -12,14 +12,14 @@ import lombok.Getter;
 public class GetSimpleAccountVideoDto {
 
   private Long videoId;
-  private String thumbnailPath;
+  private String thumbnailUrl;
   private String title;
   private String videoAdminState;
 
   public static GetSimpleAccountVideoDto fromEntity(Video video) {
     return GetSimpleAccountVideoDto.builder()
         .videoId(video.getId())
-        .thumbnailPath(video.getThumbnailUrl())
+        .thumbnailUrl(video.getThumbnailUrl())
         .title(video.getTitle())
         .videoAdminState(video.isAdminDeleteYn() ? "deleted" : null)
         .build();


### PR DESCRIPTION
<!-- 
    PR 제목은 다음과 같은 형식으로 작성합니다.

    gitmoji [Feature/domain-issue number] title
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
    
    PR에 사용되는 Gitmoji 가이드입니다.
    
    feat(✨) - Introduce new features
    fix(🐛) - Fix a bug
    docs(📝) - Add or update documentation
    style(🎨) - Improve structure / format of the code
    refactor(♻️) - Refactor code
    perf(⚡️) - Improve performance
    test(✅) - Add or update tests
    build(👷) - Add or update CI build system
    ci(💚) - Fix CI Build
    chore(⚙️) - Other changes 
    revert(⏪️) - Revert changes
    hotfix(🚑️) - Critical hotfix
-->

### 💡 개요
- `Response` `Dto Field` 이름 변경

### 📑 작업 사항
<!-- 진행한 작업에 관한 내용을 작성해주세요. (스크린 샷이 있다면 첨부해주세요) -->
- `GetSimpleAccountVideoDto`의 `thumbnailPath`를 `thumbnailUrl`로 변경했습니다.