### PR TITLE
[refactor] addLike 검증 로직 추가

### DIFF
--- a/src/main/java/com/numble/team3/exception/like/LikeVideoAlreadyExistsException.java
+++ b/src/main/java/com/numble/team3/exception/like/LikeVideoAlreadyExistsException.java
@@ -1,0 +1,5 @@
+package com.numble.team3.exception.like;
+
+public class LikeVideoAlreadyExistsException extends RuntimeException {
+
+}

--- a/src/main/java/com/numble/team3/like/annotation/AddLikeVideoSwagger.java
+++ b/src/main/java/com/numble/team3/like/annotation/AddLikeVideoSwagger.java
@@ -26,8 +26,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
     ),
     @ApiResponse(
       code = 400,
-      message = "좋아요 추가 실패 \t\n 1. 존재하지 않는 비디오 \t\n 2. 쿼리 파라미터가 존재하지 않음 \t\n 3. 쿼리 파라미터의 타입이 올바르지 않음",
-      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\n\"message\" : \"존재하지 않는 비디오입니다.\"\n\"message\" : \"쿼리 파라미터를 확인해주세요.\"\n\"message\" : \"쿼리 파라미터의 타입을 확인해주세요.\"\n}"))
+      message = "좋아요 추가 실패 \t\n 1. 존재하지 않는 비디오 \t\n 2. 쿼리 파라미터가 존재하지 않음 \t\n 3. 쿼리 파라미터의 타입이 올바르지 않음 \t\n 4. 이미 관심영상(좋아요)에 추가한 영상",
+      examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\n\"message\" : \"존재하지 않는 비디오입니다.\"\n\"message\" : \"쿼리 파라미터를 확인해주세요.\"\n\"message\" : \"쿼리 파라미터의 타입을 확인해주세요.\" \n\"message\" : \"이미 관심 영상(좋아요)에 추가한 영상입니다.\"\n}"))
     ),
     @ApiResponse(
       code = 401,

--- a/src/main/java/com/numble/team3/like/application/LikeVideoService.java
+++ b/src/main/java/com/numble/team3/like/application/LikeVideoService.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 
 import com.numble.team3.account.resolver.UserInfo;
+import com.numble.team3.exception.like.LikeVideoAlreadyExistsException;
 import com.numble.team3.exception.like.LikeVideoNotFoundException;
 import com.numble.team3.exception.video.VideoNotFoundException;
 import com.numble.team3.like.application.response.GetAllLikeVideoListDto;
@@ -15,7 +16,6 @@ import com.numble.team3.like.application.response.GetVideoRankDto;
 import com.numble.team3.like.domain.LikeVideo;
 import com.numble.team3.like.domain.LikeVideoUtils;
 import com.numble.team3.like.infra.JpaLikeVideoRepository;
-import com.numble.team3.video.domain.Video;
 import com.numble.team3.video.domain.enums.VideoCategory;
 import com.numble.team3.video.infra.JpaVideoRepository;
 import java.util.ArrayList;
@@ -42,85 +42,67 @@ public class LikeVideoService {
 
   @Transactional
   public void addLike(UserInfo userInfo, Long videoId, VideoCategory category) {
-    Video video =
-        videoRepository
-            .findByAccountIdAndId(userInfo.getAccountId(), videoId)
-            .orElseThrow(VideoNotFoundException::new);
-    video.changeLikeCountMinusForDev();
+    if (likeRepository.existsLikeByVideoIdAndAccountId(videoId, userInfo.getAccountId())) {
+      throw new LikeVideoAlreadyExistsException();
+    }
 
     likeRepository.save(
-        new LikeVideo(
-            videoRepository.findById(videoId).orElseThrow(VideoNotFoundException::new),
-            userInfo.getAccountId(),
-            category));
+      new LikeVideo(
+        videoRepository.findById(videoId).orElseThrow(VideoNotFoundException::new),
+        userInfo.getAccountId(),
+        category));
   }
 
   @Transactional
   public void deleteLike(UserInfo userInfo, Long videoId) {
-    Video video =
-        videoRepository
-            .findByAccountIdAndId(userInfo.getAccountId(), videoId)
-            .orElseThrow(VideoNotFoundException::new);
-    video.changeLikeCountMinusForDev();
-
     LikeVideo like =
-        likeRepository
-            .getLikeByAccountIdAndVideoId(userInfo.getAccountId(), videoId)
-            .orElseThrow(LikeVideoNotFoundException::new);
+      likeRepository.getLikeByAccountIdAndVideoId(userInfo.getAccountId(), videoId)
+        .orElseThrow(LikeVideoNotFoundException::new);
 
     likeRepository.delete(like);
   }
 
   @Transactional(readOnly = true)
   public GetLikeListDto getLikesByCategory(
-      UserInfo userInfo, String categoryName, Long likeId, int size) {
+    UserInfo userInfo,
+    String categoryName,
+    Long likeId,
+    int size) {
 
-    List<GetLikeVideoDto> likes =
-        likeRepository.getLikesByCategory(userInfo, categoryName, likeId, size);
+    List<GetLikeVideoDto> likes = likeRepository.getLikesByCategory(userInfo, categoryName, likeId, size);
 
     if (likes.size() < size) {
       return new GetLikeListDto(likes, null);
-    } else {
+    }
+    else {
       return new GetLikeListDto(likes, likes.get(likes.size() - 1).getId());
     }
   }
 
   @Transactional(readOnly = true)
   public GetAllLikeVideoListDto getLikesHierarchy(UserInfo userInfo) {
-    Map<String, List<GetLikeVideoDto>> rankHierarchy =
-        Arrays.stream(VideoCategory.values())
-            .collect(
-                groupingBy(
-                    value -> value.getName(),
-                    mapping(
-                        value ->
-                            likeRepository
-                                .getAllLikesWithLimit(userInfo.getAccountId(), value, limit)
-                                .stream()
-                                .map(like -> GetLikeVideoDto.fromEntity(like))
-                                .collect(toList()),
-                        Collector.of(
-                            ArrayList::new,
-                            List::addAll,
-                            (likes, getLikeDto) -> {
-                              likes.addAll(getLikeDto);
-                              return likes;
-                            }))));
+    Map<String, List<GetLikeVideoDto>> rankHierarchy = Arrays.stream(VideoCategory.values()).collect(
+      groupingBy(value -> value.getName(), mapping(
+        value -> likeRepository.getAllLikesWithLimit(userInfo.getAccountId(), value, limit)
+          .stream().map(like -> GetLikeVideoDto.fromEntity(like)).collect(toList()),
+        Collector.of(ArrayList::new, List::addAll, (likes, getLikeDto) -> {
+          likes.addAll(getLikeDto);
+          return likes;
+        })
+      )));
 
-    Map<String, GetLikeVideoCategoryListLimitDto> result =
-        rankHierarchy.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    entry -> entry.getKey(),
-                    entry -> {
-                      List<GetLikeVideoDto> list = rankHierarchy.get(entry.getKey());
-                      if (list.size() == 0) {
-                        return new GetLikeVideoCategoryListLimitDto(list, null);
-                      } else {
-                        return new GetLikeVideoCategoryListLimitDto(
-                            list, list.get(list.size() - 1).getId());
-                      }
-                    }));
+    Map<String, GetLikeVideoCategoryListLimitDto> result = rankHierarchy.entrySet().stream()
+      .collect(Collectors.toMap(
+        entry -> entry.getKey(),
+        entry -> {
+          List<GetLikeVideoDto> list = rankHierarchy.get(entry.getKey());
+          if (list.size() == 0) {
+            return new GetLikeVideoCategoryListLimitDto(list, null);
+          } else {
+            return new GetLikeVideoCategoryListLimitDto(list, list.get(list.size() - 1).getId());
+          }
+        }
+      ));
 
     return new GetAllLikeVideoListDto(result);
   }
@@ -136,8 +118,6 @@ public class LikeVideoService {
 
   public List<GetVideoRankDto> getRank(String standard, VideoCategory videoCategory) {
     List<GetVideoRankDto> dtos = likeVideoUtils.getDayRanking(standard);
-    return dtos.stream()
-        .filter(dto -> dto.getVideoDto().getVideoCategory().equals(videoCategory))
-        .collect(toList());
+    return dtos.stream().filter(dto -> dto.getVideoDto().getVideoCategory().equals(videoCategory)).collect(toList());
   }
 }

--- a/src/main/java/com/numble/team3/like/application/advice/LikeVideoRestControllerAdvice.java
+++ b/src/main/java/com/numble/team3/like/application/advice/LikeVideoRestControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.numble.team3.like.application.advice;
 
+import com.numble.team3.exception.like.LikeVideoAlreadyExistsException;
 import com.numble.team3.exception.like.LikeVideoNotFoundException;
 import com.numble.team3.exception.video.VideoNotFoundException;
 import com.numble.team3.like.controller.LikeVideoController;
@@ -17,14 +18,20 @@ public class LikeVideoRestControllerAdvice {
 
   @ExceptionHandler(MissingServletRequestParameterException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  Map<String, String> missingServletRequestParameterException() {
+  Map<String, String> missingServletRequestParameterExceptionHandler() {
     return createResponse("쿼리 파라미터를 확인해주세요.");
   }
 
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  Map<String, String> methodArgumentTypeMismatchException() {
+  Map<String, String> methodArgumentTypeMismatchExceptionHandler() {
     return createResponse("쿼리 파라미터의 타입을 확인해주세요.");
+  }
+
+  @ExceptionHandler(LikeVideoAlreadyExistsException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map<String, String> likeVideoAlreadyExistsExceptionHandler() {
+    return createResponse("이미 관심 영상(좋아요)에 추가한 영상입니다.");
   }
 
   @ExceptionHandler(LikeVideoNotFoundException.class)

--- a/src/main/java/com/numble/team3/like/infra/JpaLikeVideoRepository.java
+++ b/src/main/java/com/numble/team3/like/infra/JpaLikeVideoRepository.java
@@ -33,4 +33,6 @@ public interface JpaLikeVideoRepository extends JpaRepository<LikeVideo, Long>,
   @Query("SELECT l FROM LikeVideo l JOIN FETCH l.video v WHERE v.id IN :videoIds AND l.accountId = :accountId")
   List<LikeVideo> getLikesByAccountId(@Param("videoIds") List<Long> videoIds, @Param("accountId") Long accountId);
 
+  @Query("SELECT l FROM LikeVideo l JOIN FETCH l.video v WHERE v.id = :videoId AND l.accountId = :accountId")
+  boolean existsLikeByVideoIdAndAccountId(@Param("videoId") Long videoId, @Param("accountId") Long accountId);
 }


### PR DESCRIPTION
<!-- 
    PR 제목은 다음과 같은 형식으로 작성합니다.

    gitmoji [Feature/domain-issue number] title
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
    
    PR에 사용되는 Gitmoji 가이드입니다.
    
    feat(✨) - Introduce new features
    fix(🐛) - Fix a bug
    docs(📝) - Add or update documentation
    style(🎨) - Improve structure / format of the code
    refactor(♻️) - Refactor code
    perf(⚡️) - Improve performance
    test(✅) - Add or update tests
    build(👷) - Add or update CI build system
    ci(💚) - Fix CI Build
    chore(⚙️) - Other changes 
    revert(⏪️) - Revert changes
    hotfix(🚑️) - Critical hotfix
-->

### 💡 개요
- 좋아요 추가 시 검증 로직이 없어 중복으로 좋아요가 되는 것을 방지하기 위한 로직 추가

### 📑 작업 사항
- `addLike` 메소드에서 좋아요가 이미 있는지 검증하는 로직을 추가했습니다.
- `JpaLikeVideoRepository`에 `videoId`와 `accountId`로 존재유무를 확인할 수 있는 `existsLikeByVideoIdAndAccountId` 메소드를 추가했습니다.
- `LikeVideoAlreadyExistsException` 예외를 추가하고, 그에 따라 `RestControllerAdvice`에서 핸들링하도록 내용을 추가했습니다.
- 변경된 사항을 `Swagger`에 적용했습니다.